### PR TITLE
Add compas_fab repo

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -658,4 +658,5 @@ repositories = [
   'github.com/fossasia/open-event-server',
   'github.com/keptn/keptn',
   'github.com/IamStefin/Instagram-Image-Downloader',
+  'github.com/compas-dev/compas_fab',
 ]


### PR DESCRIPTION
Adding the compas fab repository, a robotic planning & execution library in python. Focused on architecture, engineering and construction sectors.