### PR TITLE
added azure-databricks-sdk-python 

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -681,5 +681,5 @@ repositories = [
   'github.com/creativecommons/cccatalog-api',
   'github.com/creativecommons/cccatalog-frontend',
   'github.com/jina-ai/jina/',
-  'https://github.com/aminekaabachi/azure-databricks-sdk-python',
+  'github.com/aminekaabachi/azure-databricks-sdk-python',
 ]

--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -680,5 +680,6 @@ repositories = [
   'github.com/creativecommons/cccatalog',
   'github.com/creativecommons/cccatalog-api',
   'github.com/creativecommons/cccatalog-frontend',
-  'github.com/jina-ai/jina/'
+  'github.com/jina-ai/jina/',
+  'https://github.com/aminekaabachi/azure-databricks-sdk-python',
 ]


### PR DESCRIPTION
azure-databricks-sdk-python is a Python SDK for the Azure Databricks REST API 2.0.
I wanted to add it to your website.