### PR TITLE
Show number of comments attached to the issue

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -4,7 +4,7 @@
       <nuxt-link to="/" class="flex items-center text-gray-700 font-bold">
         <img src="~/assets/gfi-logo-white.svg" alt="Good First Issue" class="h-12" />
       </nuxt-link>
-      <span class="text-2xl cursor-pointer" v-if="activeTag">
+      <span v-if="activeTag" class="text-2xl cursor-pointer">
         <span class="font-normal ml-2 mr-1 text-slate">/</span>
         <span class="font-semibold text-juniper">{{ activeTag.language }}</span>
       </span>
@@ -18,7 +18,10 @@ import Tags from '~/data/tags.json'
 
 export default {
   props: {
-    tag: Object
+    tag: {
+      type: Object,
+      required: true
+    }
   },
   computed: {
     activeTag: function () {

--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -45,25 +45,26 @@
         v-for="issue in repo.issues"
         :key="issue.url"
       >
-        <div class="flex flex-col sm:flex-row"
+        <span class="text-slate text-right px-2 leading-snug" style="min-width: 70px"
+          >#{{ issue.number }}</span
         >
-          <span class="text-slate text-right px-2 leading-snug" style="min-width: 70px"
-            >#{{ issue.number }}</span
+        <div class="flex">
+          <a
+            title="Open issue on GitHub"
+            :href="issue.url"
+            target="_blank"
+            class="leading-snug font-semibold hover:text-juniper text-vanilla-300"
+            >{{ issue.title }}</a
           >
-          <span
-            class="text-robin text-right px-2 leading-snug"
-            style="min-width: 70px"
+          <div
+            v-if="issue.comments_count > 0"
+            class="flex items-center ml-2"
             :title="getIssueCommentsCounterTooltip(issue)"
-            >{{ issue.comments_count }}</span
           >
+            <message-square-icon size="0.7x" />
+            <span class="ml-1 text-xs leading-snug">{{ issue.comments_count }}</span>
+          </div>
         </div>
-        <a
-          title="Open issue on GitHub"
-          :href="issue.url"
-          target="_blank"
-          class="leading-snug font-semibold hover:text-juniper text-vanilla-300"
-          >{{ issue.title }}</a
-        >
       </li>
     </ol>
   </div>
@@ -72,11 +73,15 @@
 <script>
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import { MessageSquareIcon } from 'vue-feather-icons'
 import { mapMutations } from 'vuex'
 
 dayjs.extend(relativeTime)
 
 export default {
+  components: {
+    MessageSquareIcon
+  },
   props: {
     repo: Object
   },
@@ -100,14 +105,14 @@ export default {
       toggle: 'expandIssue'
     }),
     getIssueCommentsCounterTooltip: function (issue) {
-      const numComments = issue.comments_count;
+      const numComments = issue.comments_count
       if (numComments === 0) {
-        return `There are no comments on this issue.`;
+        return `There are no comments on this issue.`
       }
       if (numComments > 1) {
-        return `There are ${numComments} comments on this issue`;
+        return `There are ${numComments} comments on this issue`
       }
-      return `There is one comment on this issue`;
+      return `There is one comment on this issue`
     }
   }
 }

--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -48,21 +48,21 @@
         <span class="text-slate text-right px-2 leading-snug" style="min-width: 70px"
           >#{{ issue.number }}</span
         >
-        <div class="flex">
+        <div class="flex items-start flex-row flex-auto">
           <a
             title="Open issue on GitHub"
             :href="issue.url"
             target="_blank"
-            class="leading-snug font-semibold hover:text-juniper text-vanilla-300"
+            class="leading-snug font-semibold hover:text-juniper text-vanilla-300 block flex-auto"
             >{{ issue.title }}</a
           >
           <div
             v-if="issue.comments_count > 0"
-            class="flex items-center ml-2"
+            class="flex flex-row items-center justify-end mt-1 w-10"
             :title="getIssueCommentsCounterTooltip(issue)"
           >
-            <message-square-icon size="0.7x" />
-            <span class="ml-1 text-xs leading-snug">{{ issue.comments_count }}</span>
+            <message-square-icon size="0.8x" class="mt-px" />
+            <span class="ml-1 text-sm leading-snug">{{ issue.comments_count }}</span>
           </div>
         </div>
       </li>
@@ -107,7 +107,7 @@ export default {
     getIssueCommentsCounterTooltip: function (issue) {
       const numComments = issue.comments_count
       if (numComments === 0) {
-        return `There are no comments on this issue.`
+        return `There are no comments on this issue`
       }
       if (numComments > 1) {
         return `There are ${numComments} comments on this issue`

--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="select-none border w-full rounded-md mb-4 cursor-pointer hover:bg-ink-300 group"
-    :class="{ 'border-juniper hover:bg-ink-400': isIssueOpen, 'border-ink-200': !isIssueOpen }"
     :id="`repo-${repo.id}`"
+    :class="{ 'border-juniper hover:bg-ink-400': isIssueOpen, 'border-ink-200': !isIssueOpen }"
+    class="select-none border w-full rounded-md mb-4 cursor-pointer hover:bg-ink-300 group"
     @click="toggle(repo.id)"
   >
     <div class="px-5 py-3">
@@ -39,11 +39,11 @@
         </div>
       </div>
     </div>
-    <ol class="px-5 py-3 text-base leading-loose border-t border-ink-200" v-if="isIssueOpen">
+    <ol v-if="isIssueOpen" class="px-5 py-3 text-base leading-loose border-t border-ink-200">
       <li
-        class="flex flex-row items-start justify-start py-1"
         v-for="issue in repo.issues"
         :key="issue.url"
+        class="flex flex-row items-start justify-start py-1"
       >
         <span class="text-slate text-right px-2 leading-snug" style="min-width: 70px"
           >#{{ issue.number }}</span
@@ -83,7 +83,10 @@ export default {
     MessageSquareIcon
   },
   props: {
-    repo: Object
+    repo: {
+      type: Object,
+      required: true
+    }
   },
   computed: {
     issuesDisplay: function () {

--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -45,9 +45,18 @@
         v-for="issue in repo.issues"
         :key="issue.url"
       >
-        <span class="text-slate text-right px-2 leading-snug" style="min-width: 70px"
-          >#{{ issue.number }}</span
+        <div class="flex flex-col sm:flex-row"
         >
+          <span class="text-slate text-right px-2 leading-snug" style="min-width: 70px"
+            >#{{ issue.number }}</span
+          >
+          <span
+            class="text-robin text-right px-2 leading-snug"
+            style="min-width: 70px"
+            :title="getIssueCommentsCounterTooltip(issue)"
+            >{{ issue.comments_count }}</span
+          >
+        </div>
         <a
           title="Open issue on GitHub"
           :href="issue.url"
@@ -89,7 +98,17 @@ export default {
   methods: {
     ...mapMutations({
       toggle: 'expandIssue'
-    })
+    }),
+    getIssueCommentsCounterTooltip: function (issue) {
+      const numComments = issue.comments_count;
+      if (numComments === 0) {
+        return `There are no comments on this issue.`;
+      }
+      if (numComments > 1) {
+        return `There are ${numComments} comments on this issue`;
+      }
+      return `There is one comment on this issue`;
+    }
   }
 }
 </script>

--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -114,6 +114,7 @@ def get_repository_info(owner, name):
                         "title": issue.title,
                         "url": issue.html_url,
                         "number": issue.number,
+                        "comments_count": issue.comments_count,
                         "created_at": issue.created_at.isoformat(),
                     }
                 )

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,14 +15,14 @@ import Navbar from '~/components/Navbar.vue'
 import Sidebar from '~/components/Sidebar.vue'
 
 export default {
+  components: {
+    Navbar,
+    Sidebar
+  },
   data: function () {
     return {
       tag: {}
     }
-  },
-  components: {
-    Navbar,
-    Sidebar
   },
   mounted() {
     this.setupMailchimpPopup()

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "core-js": "^3.6.5",
     "dayjs": "^1.9.7",
     "lodash": "^4.17.20",
-    "nuxt": "^2.14.6"
+    "nuxt": "^2.14.6",
+    "vue-feather-icons": "^5.1.0"
   },
   "devDependencies": {
     "@nuxtjs/google-analytics": "^2.4.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,13 +9,13 @@ import RepoBox from '~/components/RepoBox.vue'
 import Repositories from '~/data/generated.json'
 
 export default {
+  components: {
+    RepoBox
+  },
   data: function () {
     return {
       repos: Repositories
     }
-  },
-  components: {
-    RepoBox
   }
 }
 </script>

--- a/pages/language/_slug.vue
+++ b/pages/language/_slug.vue
@@ -11,10 +11,8 @@ import Tags from '~/data/tags.json'
 import Repositories from '~/data/generated.json'
 
 export default {
-  data: function () {
-    return {
-      repos: Repositories
-    }
+  components: {
+    RepoBox
   },
   validate({ params }) {
     return includes(map(Tags, 'slug'), params.slug)
@@ -24,8 +22,10 @@ export default {
     const tag = find(Tags, { slug: params.slug })
     return { repos, tag }
   },
-  components: {
-    RepoBox
+  data: function () {
+    return {
+      repos: Repositories
+    }
   }
 }
 </script>

--- a/static/sw.js
+++ b/static/sw.js
@@ -2,11 +2,11 @@
 
 // https://github.com/NekR/self-destroying-sw
 
-self.addEventListener('install', function (e) {
+self.addEventListener('install', function () {
   self.skipWaiting()
 })
 
-self.addEventListener('activate', function (e) {
+self.addEventListener('activate', function () {
   self.registration
     .unregister()
     .then(function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,6 +2272,11 @@ autoprefixer@^9, autoprefixer@^9.4.5, autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+babel-helper-vue-jsx-merge-props@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.3.tgz#22aebd3b33902328e513293a8e4992b384f9f1b6"
+  integrity sha512-gsLiKK7Qrb7zYJNgiXKpXblxbV5ffSwR0f5whkPAaBAR4fhi6bwRZxX9wBlIc5M/v8CCkXUbXZL4N/nSE97cqg==
+
 babel-loader@^8.2.2:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz#9363ce84c10c9a40e6c753748e1441b60c8a0b81"
@@ -9440,6 +9445,13 @@ vue-draggable-resizable@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/vue-draggable-resizable/-/vue-draggable-resizable-2.3.0.tgz#94c433ca748bc1a4d0959ba1c5c0e1c3536cee5b"
   integrity sha512-77CLRj1TPwB30pwsjOf3pkd1UzYanCdKXbqhILJ0Oo5QQl50lvBfyQCXxMFzwWwTc3sbBbQH3FfWSV+BkoSElA==
+
+vue-feather-icons@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/vue-feather-icons/-/vue-feather-icons-5.1.0.tgz#db658aca5f4c088c2f725f8b1f2967d4a1e4d398"
+  integrity sha512-ZyM2yFGmL9DYLZYHm63KV1zCQOj8czC2LzDSkxoIp9o6zMAOY4yv1FkxbX+XNUwcH3RRrAuvf25Ij7CnUUsQVA==
+  dependencies:
+    babel-helper-vue-jsx-merge-props "^2.0.2"
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"


### PR DESCRIPTION
# #173 Show number of comments attached to the issue

This required updating both the `populate` generator to include the required `comments_count` information, and of course the `RepoBox`'s collapsed issues information.

See the following screenshots for the (responsive) design, including a very simple tooltip:

![image](https://user-images.githubusercontent.com/8150831/105578118-4338f200-5d7e-11eb-8580-3725d3320902.png)

![image](https://user-images.githubusercontent.com/8150831/105578108-387e5d00-5d7e-11eb-8e92-4e10ff6f554e.png)
