### PR TITLE
Add jupyterlab-lsp

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -384,6 +384,7 @@ repositories = [
   'github.com/knex/knex',
   'github.com/kognise/water.css',
   'github.com/komeiji-satori/Dress',
+  'github.com/krassowski/jupyterlab-lsp',
   'github.com/ktorio/ktor',
   'github.com/kubeapps/kubeapps',
   'github.com/kubernetes-sigs/krew',


### PR DESCRIPTION
Proposing to add [jupyterlab-lsp](https://github.com/krassowski/jupyterlab-lsp) as we are very welcoming of new contributors :)

- [x] At least three issues with the good first issue label: [exactly three](https://github.com/krassowski/jupyterlab-lsp/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) at the moment, but will be more!
- [x] Detailed setup instructions for the project: in CONTRIBUTING.md
- [x] CONTRIBUTING.md: [yes](https://github.com/krassowski/jupyterlab-lsp/blob/master/CONTRIBUTING.md)
- [x] Actively maintained: yes