### PR TITLE
Github classroom repo has been archived

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -172,7 +172,6 @@ repositories = [
   'github.com/eclipse/che',
   'github.com/eclipse/eclipse-collections',
   'github.com/eclipsesource/J2V8',
-  'github.com/education/classroom',
   'github.com/EFForg/https-everywhere',
   'github.com/einsteinpy/einsteinpy',
   'github.com/elastic/beats',


### PR DESCRIPTION
The project is maintained internally by Github since March 2020. See their README https://github.com/education/classroom#github-classroom for details.