### PR TITLE
Added MockK repository

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -392,6 +392,7 @@ repositories = [
   'github.com/mlpack/mlpack',
   'github.com/moaazsidat/react-native-qrcode-scanner',
   'github.com/mobile-shell/mosh',
+  'github.com/mockk/mockk',
   'github.com/modin-project/modin',
   'github.com/monicahq/monica',
   'github.com/mono/mono',


### PR DESCRIPTION
This adds the [MockK](https://github.com/mockk/mockk) repo to the list of repos.

[Here](https://github.com/mockk/mockk/issues?q=is%3Aissue+is%3Aopen+label%3Agood-first-issue) is the list of open issues labeled as "good first issue" for the project.