### PR TITLE
[MAR 252] Add banner for discover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 media
 
 .nuxt
+
+static/sw.js

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -1,0 +1,43 @@
+<template>
+  <header
+    class="w-full py-4 px-6 border-b border-ink-200 transition-background duration-500"
+    :class="[`${bannerActive ? 'bg-robin' : 'bg-ink-300'}`]"
+  >
+    <span class="flex items-center justify-center flex-wrap text-sm md:text-md font-medium">
+      <span class="md:ml-2 mr-auto md:mr-0">
+        <slot name="text"></slot>
+      </span>
+      <a
+        v-if="$slots['cta']"
+        :href="ctaLink"
+        target="_blank"
+        class="flex items-center md:ml-2 mr-auto md:mr-0 mt-2 md:mt-0"
+      >
+        <slot name="cta"></slot>
+      </a>
+    </span>
+  </header>
+</template>
+
+<script>
+const BANNER_ACTIVE_TIME = 2000
+
+export default {
+  props: {
+    ctaLink: {
+      type: String,
+      default: ''
+    }
+  },
+  data() {
+    return {
+      bannerActive: true
+    }
+  },
+  mounted() {
+    setTimeout(() => {
+      this.bannerActive = false
+    }, BANNER_ACTIVE_TIME)
+  }
+}
+</script>

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -1,20 +1,12 @@
 <template>
   <header
-    class="w-full py-4 px-6 border-b border-ink-200 transition-background duration-500"
+    class="w-full py-4 px-6 border-b border-ink-200 transition-background duration-1000"
     :class="[`${bannerActive ? 'bg-robin' : 'bg-ink-300'}`]"
   >
-    <span class="flex items-center justify-center flex-wrap text-sm md:text-md font-medium">
-      <span class="md:ml-2 mr-auto md:mr-0">
-        <slot name="text"></slot>
+    <span class="flex items-center justify-center flex-wrap text-sm font-medium">
+      <span class="md:flex items-center md:ml-2 mr-auto md:mr-0">
+        <slot></slot>
       </span>
-      <a
-        v-if="$slots['cta']"
-        :href="ctaLink"
-        target="_blank"
-        class="flex items-center md:ml-2 mr-auto md:mr-0 mt-2 md:mt-0"
-      >
-        <slot name="cta"></slot>
-      </a>
     </span>
   </header>
 </template>
@@ -23,12 +15,6 @@
 const BANNER_ACTIVE_TIME = 2000
 
 export default {
-  props: {
-    ctaLink: {
-      type: String,
-      default: ''
-    }
-  },
   data() {
     return {
       bannerActive: true

--- a/components/Banner.vue
+++ b/components/Banner.vue
@@ -4,7 +4,7 @@
     :class="[`${bannerActive ? 'bg-robin' : 'bg-ink-300'}`]"
   >
     <span class="flex items-center justify-center flex-wrap text-sm font-medium">
-      <span class="md:flex items-center md:ml-2 mr-auto md:mr-0">
+      <span class="md:flex items-center">
         <slot></slot>
       </span>
     </span>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,15 @@
 <template>
   <div class="bg-ink-400 flex flex-col min-h-screen antialiased text-vanilla-300">
-    <banner cta-link="https://deepsource.io/discover">
-      <span slot="text">Find issues in any open source repository and fix them automatically with Discover.</span>
-      <template slot="cta">LEARN MORE <ExternalLinkIcon class="h-4 md:h-6 ml-1 md:ml-2 text-vanilla-400"/></template>
+    <banner>
+      {{ BANNER.TEXT }}
+      <a
+        :href="BANNER.CTA.LINK"
+        target="_blank"
+        class="flex items-center md:ml-2 mr-auto md:mr-0 mt-2 md:mt-0 whitespace-nowrap"
+      >
+        {{ BANNER.CTA.TEXT }}
+        <ExternalLinkIcon class="h-4 mb-0.5 ml-0.5 text-vanilla-400" />
+      </a>
     </banner>
     <navbar :tag="tag"></navbar>
     <main class="flex flex-1">
@@ -20,6 +27,14 @@ import Sidebar from '~/components/Sidebar.vue'
 import Banner from '~/components/Banner.vue'
 import { ExternalLinkIcon } from 'vue-feather-icons'
 
+const BANNER = {
+  TEXT: 'Find issues in any open source repository and fix them automatically with Discover.',
+  CTA: {
+    TEXT: 'LEARN MORE',
+    LINK: 'https://deepsource.io/discover'
+  }
+}
+
 export default {
   components: {
     Navbar,
@@ -27,9 +42,10 @@ export default {
     Banner,
     ExternalLinkIcon
   },
-  data: function () {
+  data: function() {
     return {
-      tag: {}
+      tag: {},
+      BANNER
     }
   },
   mounted() {
@@ -60,7 +76,7 @@ export default {
         )
       )
 
-      chimpPopupLoader.onload = function () {
+      chimpPopupLoader.onload = function() {
         document.body.appendChild(chimpPopup)
       }
       document.body.appendChild(chimpPopupLoader)

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="bg-ink-400 flex flex-col min-h-screen antialiased text-vanilla-300">
+    <banner cta-link="https://deepsource.io/discover">
+      <span slot="text">Find issues in any open source repository and fix them automatically with Discover.</span>
+      <template slot="cta">LEARN MORE <ExternalLinkIcon class="h-4 md:h-6 ml-1 md:ml-2 text-vanilla-400"/></template>
+    </banner>
     <navbar :tag="tag"></navbar>
     <main class="flex flex-1">
       <section class="container max-w-6xl mx-auto flex flex-col md:flex-row">
@@ -13,11 +17,15 @@
 <script>
 import Navbar from '~/components/Navbar.vue'
 import Sidebar from '~/components/Sidebar.vue'
+import Banner from '~/components/Banner.vue'
+import { ExternalLinkIcon } from 'vue-feather-icons'
 
 export default {
   components: {
     Navbar,
-    Sidebar
+    Sidebar,
+    Banner,
+    ExternalLinkIcon
   },
   data: function () {
     return {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -42,7 +42,7 @@ export default {
     Banner,
     ExternalLinkIcon
   },
-  data: function() {
+  data: function () {
     return {
       tag: {},
       BANNER
@@ -76,7 +76,7 @@ export default {
         )
       )
 
-      chimpPopupLoader.onload = function() {
+      chimpPopupLoader.onload = function () {
         document.body.appendChild(chimpPopup)
       }
       document.body.appendChild(chimpPopupLoader)

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,14 +1,13 @@
 <template>
   <div class="bg-ink-400 flex flex-col min-h-screen antialiased text-vanilla-300">
     <banner>
-      {{ BANNER.TEXT }}
       <a
         :href="BANNER.CTA.LINK"
         target="_blank"
-        class="flex items-center md:ml-2 mr-auto md:mr-0 mt-2 md:mt-0 whitespace-nowrap"
+        class="flex flex-row items-center text-center justify-center space-x-2"
       >
-        {{ BANNER.CTA.TEXT }}
-        <ExternalLinkIcon class="h-4 mb-0.5 ml-0.5 text-vanilla-400" />
+        <span>{{ BANNER.TEXT }}</span>
+        <ExternalLinkIcon class="md:inline-block hidden" size="1x" />
       </a>
     </banner>
     <navbar :tag="tag"></navbar>
@@ -28,9 +27,8 @@ import Banner from '~/components/Banner.vue'
 import { ExternalLinkIcon } from 'vue-feather-icons'
 
 const BANNER = {
-  TEXT: 'Find issues in any open source repository and fix them automatically with Discover.',
+  TEXT: 'Find and fix code quality issues in 10,000+ open-source projects with DeepSource Discover',
   CTA: {
-    TEXT: 'LEARN MORE',
     LINK: 'https://deepsource.io/discover'
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -494,7 +494,8 @@ module.exports = {
       colors: 'background-color, border-color, color, fill, stroke',
       opacity: 'opacity',
       shadow: 'box-shadow',
-      transform: 'transform'
+      transform: 'transform',
+      'background': 'background'
     },
     transitionTimingFunction: {
       linear: 'linear',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -496,7 +496,7 @@ module.exports = {
       opacity: 'opacity',
       shadow: 'box-shadow',
       transform: 'transform',
-      'background': 'background'
+      background: 'background'
     },
     transitionTimingFunction: {
       linear: 'linear',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,6 +36,7 @@ module.exports = {
     spacing: {
       px: '1px',
       0: '0',
+      0.5: '0.125rem',
       1: '0.25rem',
       2: '0.5rem',
       3: '0.75rem',


### PR DESCRIPTION
## Changes
A Banner component is created, with slots `text` and `cta`, and it takes a prop `ctaLink`.
The UI is built using the following mockup, https://www.figma.com/file/iOKVu5BPLjvrX2OdFPO0jG/Zeal---Components?node-id=1057%3A0

## Video Illustration
https://user-images.githubusercontent.com/68372876/107762565-3abb5200-6d53-11eb-8ca5-de413cddd834.mov

## Screenshots

**Desktop View:**
<img width="1440" alt="Screenshot 2021-02-12 at 4 59 06 PM" src="https://user-images.githubusercontent.com/68372876/107762837-a1407000-6d53-11eb-90fa-178598d9f904.png">

**Small Mobile View:**
<img width="321" alt="Screenshot 2021-02-12 at 4 59 46 PM" src="https://user-images.githubusercontent.com/68372876/107762903-b87f5d80-6d53-11eb-9238-7c4114d4e7d4.png">


Signed-off-by: Aman Sharma <aman@deepsource.io>