### PR TITLE
Add Eclipse OpenJ9 and Eclipse OMR to project list

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -171,6 +171,8 @@ repositories = [
   'github.com/EasyEngine/easyengine',
   'github.com/eclipse/che',
   'github.com/eclipse/eclipse-collections',
+  'github.com/eclipse/omr',
+  'github.com/eclipse/openj9',
   'github.com/eclipsesource/J2V8',
   'github.com/EFForg/https-everywhere',
   'github.com/einsteinpy/einsteinpy',


### PR DESCRIPTION
Hoping to add our 2 projects to the list. We are very active and have many 'good first issues' in both repositories with many developers eager to help newcomers.

Here are our project websites
https://www.eclipse.org/openj9
https://www.eclipse.org/omr