### PR TITLE
215 Last Activity

### DIFF
--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -106,7 +106,7 @@ def get_repository_info(owner, name):
             info["url"] = repository.html_url
             info["stars"] = repository.stargazers_count
             info["stars_display"] = numerize.numerize(repository.stargazers_count)
-            info["last_modified"] = repository.updated_at
+            info["last_modified"] = repository.pushed_at.isoformat()
             info["id"] = str(repository.id)
             info["objectID"] = str(repository.id)  # for indexing on algolia
 

--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -106,7 +106,7 @@ def get_repository_info(owner, name):
             info["url"] = repository.html_url
             info["stars"] = repository.stargazers_count
             info["stars_display"] = numerize.numerize(repository.stargazers_count)
-            info["last_modified"] = repository.last_modified
+            info["last_modified"] = repository.updated_at
             info["id"] = str(repository.id)
             info["objectID"] = str(repository.id)  # for indexing on algolia
 


### PR DESCRIPTION
Addresses #215 

I took on this issue because I am a first time open source contributor who was using the good-first-issue site to try and find a project to work on. However, I immediately noticed something was off with the "last modified" component. There were a bunch of repos that hadn't been touched in years that were claiming to have been modified in the past few days.

After doing some research and experimentation, it appears that for some reason GitHub is **super** lenient with what constitutes a project being "updated". Therefore to give a better idea of how active a project is, I am updating the `last_modified` attribute to use the `pushed_at` attribute from the GitHub Repository API.