### PR TITLE
Add alexellis/arkade to the list of repositories

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -6,6 +6,7 @@ repositories = [
   'github.com/airsonic/airsonic',
   'github.com/akiran/react-slick',
   'github.com/akxcv/vuera',
+  'github.com/alexellis/arkade'
   'github.com/alexfertel/rust-algorithms',
   'github.com/alexkirsz/dispatch-proxy',
   'github.com/alfasoftware/astra',


### PR DESCRIPTION
Adds alexellis/arkade to the list of repositories.

Filtered issues page can be found here: https://github.com/alexellis/arkade/labels/good%20first%20issue

Full issues list here:

https://github.com/alexellis/arkade/issues