### PR TITLE
fix: update gitopia-mirror-action version to 0.3.0

### DIFF
--- a/.github/workflows/gitopia-mirror.yml
+++ b/.github/workflows/gitopia-mirror.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - name: Gitopia Mirror Action
-        uses: gitopia/gitopia-mirror-action@v0.1.2
+        uses: gitopia/gitopia-mirror-action@v0.3.0
         with:
           gitopiaWallet: "${{ secrets.ARWEAVE_WALLET }}"
           branch: "master"


### PR DESCRIPTION
https://github.com/deepsourcelabs/good-first-issue/runs/4564937725?check_suite_focus=true is failing due to :

```
`gitopia/gitopia-mirror-action@v0.1.2`, unable to find version `v0.1.2`
```


We Should Update this to: https://github.com/deepsourcelabs/good-first-issue/blob/master/.github/workflows/gitopia-mirror.yml#L20

`v0.3.0`

#### ℹ️ Repository information

**The repository has**:

- [ ] At least three issues with the good first issue label.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
