### PR TITLE
Added ethyca repos

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -216,6 +216,8 @@ repositories = [
   'github.com/ethereum/go-ethereum',
   'github.com/ethereum/solidity',
   'github.com/ethereum/web3.py',
+  'github.com/ethyca/fides',
+  'github.com/ethyca/fidesops',
   'github.com/evhub/coconut',
   'github.com/ezaquarii/vpn-at-home',
   'github.com/facebook/docusaurus',


### PR DESCRIPTION
Updating with Ethyca's 2 open-source repos

#### ℹ️ Repository information
Links to the issues pages of the 2 repositories that were just added, an open-source privacy engineering platform:
* https://github.com/ethyca/fides/issues
* https://github.com/ethyca/fidesops/issues

For additional information on how Ethyca is democratizing data privacy for all software builders, [visit our website](https://ethyca.com/fides)

**The repository has**:

- [x] At least three issues with the good first issue label.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
