### PR TITLE
fix: remove duplicate repository entry

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -757,7 +757,6 @@ repositories = [
   'github.com/vicky002/AlgoWiki',
   'github.com/vimeo/psalm',
   'github.com/vmware-tanzu/carvel',
-  'github.com/vmware/versatile-data-kit',
   'github.com/vmware-tanzu/community-edition',
   'github.com/vmware-tanzu/velero',
   'github.com/vmware/versatile-data-kit',


### PR DESCRIPTION
Removes duplicate listing of repository `github.com/vmware/versatile-data-kit`.