### PR TITLE
Update deploy hook, add local development details

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Trigger deployment
         uses: joelwmale/webhook-action@master
         env:
-          WEBHOOK_URL: ${{ secrets.NETLIFY_CRON_BUILD_HOOK }}
+          WEBHOOK_URL: ${{ secrets.DEPLOY_HOOK_URL }}
           data: ""

--- a/README.md
+++ b/README.md
@@ -23,18 +23,42 @@ Follow these simple steps:
 
 - Our goal is to narrow down projects for new open-source contributors. To maintain the quality of projects in Good First Issue, please make sure your GitHub repository meets the following criteria:
 
-  - At least three issues with the `good first issue` label. This label is already present on all repositories by default. If not, you can follow the steps [here](https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests).
+  - It has at least three issues with the `good first issue` label. This label is already present on all repositories by default. If not, you can follow the steps [here](https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests).
 
-  - At least 10 contributors.
+  - It has at least 10 contributors.
 
-  - Detailed setup instructions for the project.
+  - It contains a README.md with detailed setup instructions for the project, and a CONTRIBUTING.md with guidelines for new contributors.
 
-  - CONTRIBUTING.md
-
-  - Actively maintained.
+  - It is actively maintained.
 
 - Add your repository's path (in lexicographic order) in [data/repositories.toml](data/repositories.toml).
 
 - Create a new pull-request. Please add the link to the issues page of the repository in the PR description. Once the pull request is merged, the changes will be live on [goodfirstissue.dev](https://goodfirstissue.dev/).
 
-We hangout in our [Discord server](https://deepsource.io/discord). Stop by to say hi! 🙌🏼
+## Setting up the project locally
+
+Good First Issue has two components — the front-end app built with Nuxt.js and a data population script written in Python.
+
+To contribute new features and changes to the website, you would want to run the app locally. Please follow these steps:
+
+1. Clone the project locally. Make sure you have Python 3 and a recent version of Node.js installed on your computer.
+
+2. Make a copy of the sample data files for your local app to use and rename them to the filename that the app expects. **This step is important, as the front-end app won't work without these data files.**
+
+```bash
+$ cp data/generated.sample.json data/generated.json
+$ cp data/tags.sample.json data/tags.json
+```
+
+3. Build the front-end app and start the development server.
+
+```bash
+$ yarn # install the dependencies
+$ yarn dev -o # start the development server
+```
+
+The app should open in your browser.
+
+## Support
+
+We usually hang out in our [Discord server](https://deepsource.io/discord). Stop by to say hi! 🙌🏼


### PR DESCRIPTION
Changes:

 - Since we've changed how the production app is deployed, the deploy
   hook needs to be pointed to the new hosting provider. The URL has been
changed on GitHub Secrets and the variable name has been updated in the
cron config.

 - Several users have asked for details on how to run the app locally with
   dummy data. Those details have been added in the README.
