### PR TITLE
Removing archived repoistories

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -794,8 +794,5 @@ repositories = [
   'github.com/zio/zio',
   'github.com/zsh-users/zsh-completions',
   'github.com/zsh-users/zsh-syntax-highlighting',
-  'github.com/zulip/zulip',
-  'github.com/ZupIT/charlescd',
-  'github.com/ZupIT/ritchie-cli',
-  'github.com/ZupIT/ritchie-formulas'
+  'github.com/zulip/zulip'
  ]


### PR DESCRIPTION
Following repositories have been archived and are read-only, so they are unable to be contributed to:
https://github.com/ZupIT/ritchie-formulas,
https://github.com/ZupIT/ritchie-cli,
https://github.com/ZupIT/charlescd,

#### ℹ️ Repository information

**The repository has**:

- [ ] At least three issues with the `good first issue` label.
- [ ] At least 10 contributors.
- [ ] Detailed setup instructions for the project.
- [ ] CONTRIBUTING.md
- [ ] Actively maintained.
