### PR TITLE
remove deprecated sourcerer repo

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -653,7 +653,6 @@ repositories = [
   'github.com/solidusio/solidus',
   'github.com/sorbet/sorbet',
   'github.com/sourcegraph/sourcegraph',
-  'github.com/sourcerer-io/sourcerer-app',
   'github.com/spaceuptech/space-cloud',
   'github.com/spack/spack',
   'github.com/splitbrain/dokuwiki',


### PR DESCRIPTION
It was closed about 1,5 year ago, so I cleared this url during #hacktoberfest