### PR TITLE
docs: add ZITADEL to the repositories list

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -798,6 +798,7 @@ repositories = [
   'github.com/zeit/next.js',
   'github.com/zephyrproject-rtos/zephyr',
   'github.com/zio/zio',
+  'github.com/zitadel/zitadel',
   'github.com/zsh-users/zsh-completions',
   'github.com/zsh-users/zsh-syntax-highlighting',
   'github.com/zulip/zulip',


### PR DESCRIPTION
#### ℹ️ Repository information

You can find all ZITADEL Issues here: https://github.com/zitadel/zitadel/issues

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
