### PR TITLE
Expand issue when user clicks the issue title.

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -56,6 +56,7 @@
             target="_blank"
             rel="noopener noreferrer"
             class="leading-snug font-semibold hover:text-juniper text-vanilla-300 block flex-auto"
+            @click="toggle(repo.id)"
             >{{ issue.title }}</a
           >
           <div


### PR DESCRIPTION
When you click the issue tittle, the issue `shrinks/closes`. Expanding it again using `toggle(id)` when the hyperlink is clicked gives us better experience.