### PR TITLE
Add collective/icalendar

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -130,6 +130,7 @@ repositories = [
   'github.com/coder/modules',
   'github.com/coder/terraform-provider-coder',
   'github.com/collectd/collectd',
+  'github.com/collective/icalendar',
   'github.com/commandlineparser/commandline',
   'github.com/compas-dev/compas_fab',
   'github.com/composer/composer',


### PR DESCRIPTION
This adds https://github.com/collective/icalendar/ We have several good first issues and extensive instructions on how to set this up.

#### ℹ️ Repository information

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
