### PR TITLE
Add link to CONTRIBUTING.md in README for easier contributions (#2466)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,39 +7,50 @@
 
 Welcome! 👋🏼
 
-**Good First Issue** is an initiative to curate easy pickings from popular projects, so developers who've never contributed to open-source can get started quickly.
+**Good First Issue** is an initiative to curate easy pickings from popular projects, so developers who've never
+contributed to open-source can get started quickly.
 
-Open-source maintainers are always looking to get more people involved, but new developers generally think it's challenging to become a contributor. We believe getting developers to fix super-easy issues removes the barrier for future contributions. This is why Good First Issue exists.
+Open-source maintainers are always looking to get more people involved, but new developers generally think it's
+challenging to become a contributor. We believe getting developers to fix super-easy issues removes the barrier for
+future contributions. This is why Good First Issue exists.
 
 ## Adding a new project
 
-You're welcome to add a new project in Good First Issue, and we encourage all projects &mdash; old and new, big and small.
+You're welcome to add a new project in Good First Issue, and we encourage all projects &mdash; old and new, big and
+small.
 
 Follow these simple steps:
 
-- Our goal is to narrow down projects for new open-source contributors. To maintain the quality of projects in Good First Issue, please make sure your GitHub repository meets the following criteria:
+- Our goal is to narrow down projects for new open-source contributors. To maintain the quality of projects in Good
+  First Issue, please make sure your GitHub repository meets the following criteria:
 
-  - It has at least three issues with the `good first issue` label. This label is already present on all repositories by default. If not, you can follow the steps [here](https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests).
+  - It has at least three issues with the `good first issue` label. This label is already present on all repositories by
+    default. If not, you can follow the
+    steps [here](https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests).
 
   - It has at least 10 contributors.
 
-  - It contains a README.md with detailed setup instructions for the project, and a CONTRIBUTING.md with guidelines for new contributors.
+  - It contains a README.md with detailed setup instructions for the project, and a [CONTRIBUTING.md](https://opensource.guide/) with guidelines for
+    new contributors.
 
   - It is actively maintained.
 
 - Add your repository's path (in lexicographic order) in [data/repositories.toml](data/repositories.toml).
 
-- Create a new pull-request. Please add the link to the issues page of the repository in the PR description. Once the pull request is merged, the changes will be live on [goodfirstissue.dev](https://goodfirstissue.dev/).
+- Create a new pull-request. Please add the link to the issues page of the repository in the PR description. Once the
+  pull request is merged, the changes will be live on [goodfirstissue.dev](https://goodfirstissue.dev/).
 
 ## Setting up the project locally
 
-Good First Issue has two components — the front-end app built with Nuxt.js and a data population script written in Python.
+Good First Issue has two components — the front-end app built with Nuxt.js and a data population script written in
+Python.
 
 To contribute new features and changes to the website, you would want to run the app locally. Please follow these steps:
 
 1. Clone the project locally. Make sure you have Python 3 and a recent version of Node.js installed on your computer.
 
-2. Make a copy of the sample data files for your local app to use and rename them to the filename that the app expects. **This step is important, as the front-end app won't work without these data files.**
+2. Make a copy of the sample data files for your local app to use and rename them to the filename that the app expects.
+   **This step is important, as the front-end app won't work without these data files.**
 
 ```bash
 $ cp data/generated.sample.json data/generated.json


### PR DESCRIPTION
This PR addresses issue #2466 by adding a direct link to the CONTRIBUTING.md file in the README under the “Contributing” section.