### PR TITLE
docs: fix outdated GitHub labels documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Welcome! 👋🏼
 
 Open-source maintainers are always looking to get more people involved, but new developers generally think it's challenging to become a contributor. We believe getting developers to fix super-easy issues removes the barrier for future contributions. This is why Good First Issue exists.
 
+The Link to Contribution Guide:https://github.com/DeepSourceCorp/good-first-issue/issues/created_by/CONTRIBUTING.md
+
 ## Adding a new project
 
 You're welcome to add a new project in Good First Issue, and we encourage all projects &mdash; old and new, big and small.


### PR DESCRIPTION
#  Summary
The GitHub documentation link for applying issue labels pointed to an outdated help.github.com URL. Updated it to the current docs.github.com equivalent.

## Changes

Updated broken GitHub documentation link in README.

## Why

New contributors rely on this link to correctly apply good first issue labels.

help.github.com redirects inconsistently and may fail depending on region.

## Additional Context
This helps first-time contributors follow proper labeling guidelines.