### PR TITLE
Clarify ignore rules for minified JavaScript files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,8 @@ insert_final_newline = true
 insert_final_newline = ignore
 
 # Minified JavaScript files shouldn't be changed
-[**.min.js]
+# Ignore minified JS files because formatting them can break them
+[**/*.min.js]
 indent_style = ignore
 insert_final_newline = ignore
 


### PR DESCRIPTION
 Corrected the  `[**.min.js]` → `[**/*.min.js]` to match all minified JS files in any folder.
 Keeps the existing comment for clarity.
 Ensures minified files are not accidentally reformatted.

#### ℹ️ Repository information

**The repository has**:

- [ ] At least three issues with the `good first issue` label.
- [ ] At least 10 contributors.
- [ ] Detailed setup instructions for the project.
- [ ] CONTRIBUTING.md
- [ ] Actively maintained.
