### PR TITLE
docs: fix outdated GitHub help link in README (fixes #2471)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Follow these simple steps:
 
 - Our goal is to narrow down projects for new open-source contributors. To maintain the quality of projects in Good First Issue, please make sure your GitHub repository meets the following criteria:
 
-  - It has at least three issues with the `good first issue` label. This label is already present on all repositories by default. If not, you can follow the steps [here](https://help.github.com/en/github/managing-your-work-on-github/applying-labels-to-issues-and-pull-requests).
+  - It has at least three issues with the `good first issue` label. This label is already present on all repositories by default. If not, you can follow the steps [here](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels).
 
   - It has at least 10 contributors.
 


### PR DESCRIPTION
### Summary
Fixed an outdated GitHub documentation link in the README file.

### Changes
- Updated link under “Adding a new project” → now points to correct GitHub Docs page.

### Why
The previous link (help.github.com) was broken.  
This ensures new contributors can access the correct guide on managing labels.

### Related Issue
Fixes #2471
