### PR TITLE
Add Foobara to data/repositories.toml

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -248,6 +248,7 @@ repositories = [
   'github.com/flarum/core',
   'github.com/flipt-io/flipt',
   'github.com/fluffyP4nd4/NoteIt',
+  'github.com/foobara/foobara',
   'github.com/fortio/fortio',
   'github.com/fossasia/open-event-server',
   'github.com/Foundry376/Mailspring',


### PR DESCRIPTION
The project's issues page is here: https://github.com/foobara/foobara/issues

#### ℹ️ Repository information

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
