### PR TITLE
chore: fail fast on cron generate step

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -26,9 +26,12 @@ jobs:
           bun install
 
       - name: Populate the latest data
-        run: make generate
+        run: |
+           set -e
+           make generate
         env:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
 
       - name: Sync data to the blob store
         run: bun sync up


### PR DESCRIPTION
This change makes the cron workflow fail fast during the `make generate` step
by using `set -e`.

It does not change behavior or output, but avoids false-success runs and makes
authentication failures (401 Bad credentials) clearly visible in GitHub Actions logs.

