### PR TITLE
Add Puter to repository list

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -315,6 +315,7 @@ repositories = [
   'github.com/Heptagram-Bot/Heptagram',
   'github.com/Hermit-Tools/Thumbnail-Maker',
   'github.com/hewiefreeman/GopherGameServer',
+  'github.com/HeyPuter/puter',
   'github.com/hoppscotch/hoppscotch',
   'github.com/http4s/http4s',
   'github.com/hubtype/botonic',


### PR DESCRIPTION
Added HeyPuter/puter to the repository list.
  
  Issues page: https://github.com/HeyPuter/puter/issues
  This project has beginner-friendly issues and is actively maintained.