### PR TITLE
Add Code of Conduct section to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 Thanks for your interest in contributing! This guide will help you get started.
 
+## Code of Conduct
+
+This project is committed to providing a welcoming and inclusive environment for all contributors.
+
+All participants are expected to uphold respectful and professional behavior when contributing to this project, including in issues, pull requests, and other community interactions.
+
+This project follows the principles of the **Contributor Covenant Code of Conduct**. By participating, you agree to abide by its terms.
+
+If you experience or witness unacceptable behavior, please report it to the project maintainers by opening a GitHub issue or contacting the maintainers privately.
+
+For more details, see the Contributor Covenant:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+
 ## Prerequisites
 
 Before you begin, make sure you have the following installed:
@@ -100,3 +114,5 @@ make format
 1. Create a new branch for your changes
 2. Make your changes and test them locally
 3. Submit a pull request with a clear description of what you changed and why
+
+


### PR DESCRIPTION
## Summary
This PR adds a **Code of Conduct** section to `CONTRIBUTING.md` to clarify community expectations and promote a welcoming, inclusive contribution environment.

## Motivation
While the contributing guide clearly explains the technical workflow, it did not include guidance on expected community behavior. Adding a Code of Conduct aligns the project with common open-source best practices and GitHub recommendations.

## Changes
- Added a new **Code of Conduct** section at the end of `CONTRIBUTING.md`
- Referenced the Contributor Covenant as a widely adopted standard

## Notes
This change does not affect any functionality and is purely documentation-related.
