### PR TITLE
Include guidance for non-native English speakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 
 Welcome! 👋🏼
 
+**For non-native English speakers**
+
+This project is primarily documented in English.
+If you're new to open source or not confident with English yet, feel free to use translation tools.
+Many contributors started the same way.
+
+
 **Good First Issue** is an initiative to curate easy pickings from popular projects, so developers who've never contributed to open-source can get started quickly.
 
 Open-source maintainers are always looking to get more people involved, but new developers generally think it's challenging to become a contributor. We believe getting developers to fix super-easy issues removes the barrier for future contributions. This is why Good First Issue exists.


### PR DESCRIPTION
### What
Added a short section to the README for non-native English speakers.

### Why
To make the project more welcoming and lower the barrier for first-time open source contributors.
