### PR TITLE
Add Foobara to data/repositories.toml

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -237,6 +237,7 @@ repositories = [
   'github.com/flarum/core',
   'github.com/flipt-io/flipt',
   'github.com/flutter/flutter',
+  'github.com/foobara/foobara',
   'github.com/fortio/fortio',
   'github.com/fossasia/open-event-server',
   'github.com/Foundry376/Mailspring',


### PR DESCRIPTION
Originally submitted as https://github.com/DeepSourceCorp/good-first-issue/pull/2525 but strangely didn't show proper contributor count or something. So submitting again!

The project is at: https://github.com/foobara/foobara
And its issues page is at: https://github.com/foobara/foobara/issues

#### ℹ️ Repository information

**The repository has**:

- [x] At least three issues with the `good first issue` label.
- [x] At least 10 contributors.
- [x] Detailed setup instructions for the project.
- [x] CONTRIBUTING.md
- [x] Actively maintained.
