### PR TITLE
Add tech stack, architecture, and quick start sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,75 @@ Welcome! 👋🏼
 
 Open-source maintainers are always looking to get more people involved, but new developers generally think it's challenging to become a contributor. We believe getting developers to fix super-easy issues removes the barrier for future contributions. This is why Good First Issue exists.
 
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | [Nuxt.js 3](https://nuxt.com/) (Vue.js) |
+| Styling | [Tailwind CSS](https://tailwindcss.com/) |
+| Data Pipeline | Python 3.12 |
+| JS Package Manager | [Bun](https://bun.sh/) |
+| Python Package Manager | [uv](https://docs.astral.sh/uv/) |
+| Hosting | [Vercel](https://vercel.com/) |
+| Data Storage | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) |
+
+## How It Works
+
+Good First Issue consists of two main parts:
+
+1. **Data Pipeline (Python)** — A script (`gfi/populate.py`) reads the curated repository list from `data/repositories.toml` (~800+ repos), fetches metadata and beginner-friendly issues via the GitHub API, and outputs JSON data files.
+2. **Frontend (Nuxt.js)** — A static site generated from the JSON data, allowing users to browse repositories and filter by programming language.
+
+A daily cron job refreshes the data automatically and triggers a redeployment.
+
+## Quick Start
+
+```bash
+# Clone and enter the project
+git clone https://github.com/DeepSourceCorp/good-first-issue.git
+cd good-first-issue
+
+# Set up Python environment
+uv sync --all-extras
+
+# Copy sample data for local development
+cp data/generated.sample.json data/generated.json
+cp data/tags.sample.json data/tags.json
+
+# Install frontend dependencies and start dev server
+bun install
+bun dev
+```
+
+The app will be available at [http://localhost:3000](http://localhost:3000). See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup details.
+
+## Project Structure
+
+```
+├── components/        # Vue components (Navbar, Sidebar, RepoBox, etc.)
+├── composables/       # Shared Vue state
+├── data/              # Repository list (TOML) and generated JSON data
+├── gfi/               # Python data pipeline (populate.py, tests)
+├── layouts/           # Nuxt layout templates
+├── pages/             # Nuxt pages (index, language filter)
+├── public/            # Static assets (icons, images)
+├── Makefile           # Build automation commands
+├── nuxt.config.ts     # Nuxt configuration
+└── pyproject.toml     # Python project configuration
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `bun dev` | Start the development server |
+| `bun generate` | Generate the static site |
+| `make generate` | Fetch fresh data from GitHub (requires `GH_ACCESS_TOKEN`) |
+| `make test` | Run data sanity tests and type checking |
+| `make format` | Format code with Ruff and Prettier |
+| `make pre-build` | Set up Python environment |
+
 ## Adding a new project
 
 You're welcome to add a new project to Good First Issue, and we encourage all projects &mdash; old and new, big and small.
@@ -33,3 +102,7 @@ Once your submission is reviewed and approved, it will be added to [goodfirstiss
 ## Contributing
 
 Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and guidelines.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- Add **Tech Stack** table listing all key technologies (Nuxt.js, Tailwind, Python, Bun, uv, Vercel)
- Add **How It Works** section explaining the data pipeline and frontend architecture
- Add **Quick Start** guide so new contributors can set up locally in seconds
- Add **Project Structure** directory tree for codebase orientation
- Add **Available Commands** reference table for common dev tasks
- Add **License** section at the bottom

## Motivation

The current README covers what the project is and how to add repositories, but lacks context that helps new contributors understand the tech stack, architecture, and how to get started. These additions lower the barrier for first-time contributors.

## Test plan
- [ ] Verify all links in the README resolve correctly
- [ ] Confirm the Quick Start steps match the existing CONTRIBUTING.md instructions
- [ ] Check that the project structure tree matches the actual directory layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)