### PR TITLE
Add subtle indicator for recently updated repositories

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -38,9 +38,18 @@
       >
         <div class="mr-4"><span class="text-vanilla-400">lang: </span>{{ repo.language }}</div>
         <div class="mr-4"><span class="text-vanilla-400">stars: </span>{{ repo.stars_display }}</div>
-        <div class="mr-4">
-          <span class="text-vanilla-400">last activity: </span><span>{{ lastModifiedDisplay }}</span>
-        </div>
+        <div class="mr-4 flex items-center gap-1">
+        <span class="text-vanilla-400">last activity: </span>
+       <span>{{ lastModifiedDisplay }}</span>
+
+      <span
+       v-if="isRecentlyUpdated"
+       class="ml-1 inline-flex items-center text-xs font-semibold text-juniper"
+        title="Recently updated">
+    • recent
+  </span>
+</div>
+
       </div>
     </div>
     <ol v-if="isCardOpen" class="px-5 py-3 text-base leading-loose border-t border-ink-200">
@@ -93,6 +102,12 @@ const issuesDisplay = computed(() => {
 const lastModifiedDisplay = computed(() => {
   return dayjs(props.repo.last_modified).fromNow()
 })
+
+const isRecentlyUpdated = computed(() => {
+  const lastModified = dayjs(props.repo.last_modified)
+  return dayjs().diff(lastModified, 'hour') <= 48
+})
+
 
 const isCardOpen = computed(() => {
   return openRepoId.value === props.repo.id


### PR DESCRIPTION
## What does this PR do?

This PR adds a small, subtle visual indicator to help users quickly identify
repositories that have been updated recently while browsing the list.

The indicator appears next to the existing “last activity” text and is purely
informational.

---

## Why is this change needed?

Good First Issue is often used by new contributors who want to work on actively
maintained projects. While relative timestamps (e.g. “2 days ago”) already
exist, they can be hard to scan quickly across a long list of repositories.

A lightweight visual cue improves scannability and discoverability without
changing any existing behavior.

---

## Implementation details

- UI-only change
- Uses existing `last_modified` data
- No changes to sorting, filtering, or backend logic
- A repository is considered “recently updated” if it was modified within the
  last **48 hours** (threshold can be adjusted based on feedback)
- The indicator is intentionally subtle

