### PR TITLE
Add compatibilityDate to Nuxt config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,9 @@
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ['@nuxtjs/tailwindcss', 'nuxt-gtag', 'nuxt-simple-sitemap'],
+  compatibilityDate: '2026-02-10;,  
   nitro: {
     prerender: {
       crawlLinks: true


### PR DESCRIPTION
This PR adds a compatibilityDate to nuxt.config.ts to address the Nuxt warning shown during local development.

