### PR TITLE
Display issue creation date in repo card

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -55,6 +55,11 @@
             class="leading-snug font-medium hover:text-juniper text-vanilla-300 block flex-auto"
             >{{ issue.title }}</a
           >
+          <span
+            v-if="issue.created_at"
+            class="text-vanilla-400 text-sm leading-snug font-mono whitespace-nowrap ml-2 mt-0.5"
+            :title="new Date(issue.created_at).toLocaleDateString()"
+          >{{ dayjs(issue.created_at).fromNow() }}</span>
           <div
             v-if="issue.comments_count > 0"
             class="flex flex-row items-center justify-end mt-1 w-10"


### PR DESCRIPTION
## Summary
- Show a relative timestamp (e.g., "3 months ago") next to each issue in the expanded repo card, helping users identify and skip stale issues
- Uses the existing `created_at` data already provided by the backend and the `dayjs` relative time plugin already imported in the component
- Hover tooltip shows the exact date

Closes #736

## Test plan
- [ ] Expand a repo card and verify relative dates appear next to each issue
- [ ] Hover over the date to confirm the exact date tooltip displays correctly
- [ ] Verify layout looks correct on both desktop and mobile viewports