### PR TITLE
feat: filter repositories by stars and last activity

### DIFF
--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -30,16 +30,45 @@
       </div>
     </div>
     <div class="pt-6">
+      <h3 class="section-heading">Filter by stars</h3>
+      <select v-model.number="minStars" class="filter-select">
+        <option :value="0">All</option>
+        <option :value="100">100+</option>
+        <option :value="500">500+</option>
+        <option :value="1000">1K+</option>
+        <option :value="5000">5K+</option>
+        <option :value="10000">10K+</option>
+      </select>
+    </div>
+    <div class="pt-4">
+      <h3 class="section-heading">Filter by last activity</h3>
+      <select v-model.number="maxInactivityMonths" class="filter-select">
+        <option :value="0">All</option>
+        <option :value="1">Last month</option>
+        <option :value="3">Last 3 months</option>
+        <option :value="6">Last 6 months</option>
+        <option :value="12">Last year</option>
+        <option :value="24">Last 2 years</option>
+      </select>
+    </div>
+    <div v-if="isFilterActive" class="pt-4">
+      <button
+        class="w-full bg-ink-200 hover:bg-cherry text-vanilla-300 hover:text-ink-400 uppercase rounded-md font-bold text-center text-sm px-1 py-3 transition-colors"
+        @click="clearFilters"
+      >
+        Clear filters
+      </button>
+    </div>
+    <div class="pt-6">
       <a
         class="bg-juniper hover:bg-light_juniper text-ink-400 uppercase rounded-md font-bold text-center px-1 py-3 flex flex-row items-center justify-center space-x-1"
         href="https://github.com/deepsourcelabs/good-first-issue#adding-a-new-project"
         target="_blank"
         rel="noopener noreferrer"
-        >
-          <PlusCircleIcon class="h-5 w-5 stroke-2" />
-          <span>Add your project</span>
-        </a
       >
+        <PlusCircleIcon class="h-5 w-5 stroke-2" />
+        <span>Add your project</span>
+      </a>
     </div>
 
     <div class="text-sm pt-6">
@@ -63,7 +92,22 @@
 <script setup>
 import Tags from '~/data/tags.json'
 import { PlusCircleIcon } from '@heroicons/vue/24/outline'
-import {HeartIcon} from '@heroicons/vue/24/solid'
+import { HeartIcon } from '@heroicons/vue/24/solid'
+
+const minStars = useMinStars()
+const maxInactivityMonths = useMaxInactivityMonths()
+const router = useRouter()
+const route = useRoute()
+
+const isFilterActive = computed(() => {
+  return minStars.value > 0 || maxInactivityMonths.value > 0 || route.params.slug
+})
+
+function clearFilters() {
+  minStars.value = 0
+  maxInactivityMonths.value = 0
+  router.push('/')
+}
 </script>
 <style>
 .section-heading {
@@ -75,5 +119,10 @@ import {HeartIcon} from '@heroicons/vue/24/solid'
 
 .active-pill > span {
   @apply text-juniper;
+}
+
+.filter-select {
+  @apply w-full bg-ink-300 border border-ink-200 text-vanilla-300 text-sm rounded-md px-3 py-2 cursor-pointer;
+  @apply hover:border-juniper focus:border-juniper focus:outline-none;
 }
 </style>

--- a/composables/states.js
+++ b/composables/states.js
@@ -1,1 +1,3 @@
 export const useOpenRepoId = () => useState('openRepoId', () => null)
+export const useMinStars = () => useState('minStars', () => 0)
+export const useMaxInactivityMonths = () => useState('maxInactivityMonths', () => 0)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,19 +1,52 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in Repositories" :key="repo.id" :repo="repo" />
+    <RepoBox v-for="repo in filteredRepositories" :key="repo.id" :repo="repo" />
+    <p v-if="filteredRepositories.length === 0" class="text-vanilla-400 text-center py-8">
+      No repositories match the selected filters.
+    </p>
   </div>
 </template>
 
 <script setup>
+import dayjs from 'dayjs'
 import Repositories from '~/data/generated.json'
+
+const minStars = useMinStars()
+const maxInactivityMonths = useMaxInactivityMonths()
+
+const filteredRepositories = computed(() => {
+  let repos = Repositories.filter((repo) => {
+    if (minStars.value > 0 && repo.stars < minStars.value) {
+      return false
+    }
+    if (maxInactivityMonths.value > 0) {
+      const cutoff = dayjs().subtract(maxInactivityMonths.value, 'month')
+      if (dayjs(repo.last_modified).isBefore(cutoff)) {
+        return false
+      }
+    }
+    return true
+  })
+
+  // Sort by stars (highest first) when star filter is active,
+  // otherwise sort by last activity (most recent first) when activity filter is active
+  if (minStars.value > 0) {
+    repos = repos.slice().sort((a, b) => b.stars - a.stars)
+  } else if (maxInactivityMonths.value > 0) {
+    repos = repos.slice().sort((a, b) => dayjs(b.last_modified).unix() - dayjs(a.last_modified).unix())
+  }
+
+  return repos
+})
 
 useHead({
   title: 'Good First Issue: Make your first open-source contribution',
   meta: [
-  {
-    name: 'description',
-    content: 'Making your first open-source contribution is easier than you think. Good First Issue is a curated list of issues from popular open-source projects that you can easily fix. Start today!'
-  }
+    {
+      name: 'description',
+      content:
+        'Making your first open-source contribution is easier than you think. Good First Issue is a curated list of issues from popular open-source projects that you can easily fix. Start today!'
+    }
   ]
 })
 </script>

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -1,24 +1,59 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
+    <RepoBox v-for="repo in filteredRepositories" :key="repo.id" :repo="repo" />
+    <p v-if="filteredRepositories.length === 0" class="text-vanilla-400 text-center py-8">
+      No repositories match the selected filters.
+    </p>
   </div>
 </template>
 
 <script setup>
+import dayjs from 'dayjs'
 import Repositories from '~/data/generated.json'
 import Tags from '~/data/tags.json'
 
 const route = useRoute()
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const minStars = useMinStars()
+const maxInactivityMonths = useMaxInactivityMonths()
 
-const tag = Tags.find(t => t.slug === route.params.slug)
+const filteredRepositories = computed(() => {
+  let repos = Repositories.filter((repo) => {
+    if (repo.slug !== route.params.slug) {
+      return false
+    }
+    if (minStars.value > 0 && repo.stars < minStars.value) {
+      return false
+    }
+    if (maxInactivityMonths.value > 0) {
+      const cutoff = dayjs().subtract(maxInactivityMonths.value, 'month')
+      if (dayjs(repo.last_modified).isBefore(cutoff)) {
+        return false
+      }
+    }
+    return true
+  })
+
+  // Sort by stars (highest first) when star filter is active,
+  // otherwise sort by last activity (most recent first) when activity filter is active
+  if (minStars.value > 0) {
+    repos = repos.slice().sort((a, b) => b.stars - a.stars)
+  } else if (maxInactivityMonths.value > 0) {
+    repos = repos.slice().sort((a, b) => dayjs(b.last_modified).unix() - dayjs(a.last_modified).unix())
+  }
+
+  return repos
+})
+
+const tag = Tags.find((t) => t.slug === route.params.slug)
 
 useHead({
   title: `${tag.language} | Good First Issue`,
-  meta: [{
-    name: 'description',
-    content: `Curated list of issues in ${tag.language} from popular open-source projects that you can easily fix.`
-  }]
+  meta: [
+    {
+      name: 'description',
+      content: `Curated list of issues in ${tag.language} from popular open-source projects that you can easily fix.`
+    }
+  ]
 })
 </script>


### PR DESCRIPTION
## Description
Adds filtering capabilities to help users find repositories by popularity (stars) and recent activity, as requested in #2615.

## Changes
- **Filter by Stars**: Dropdown with options (All, 100+, 500+, 1K+, 5K+, 10K+)
- **Filter by Last Activity**: Dropdown with options (All, Last month, 3/6/12/24 months)
- **Sorting**: Repos are sorted by stars (highest first) when star filter active, or by most recent activity when activity filter active
- **Clear Filters button**: Resets all filters including language selection
- **Empty state**: Shows a message when no repos match
- Works on both home page and language-specific pages

## Files Changed
- composables/states.js — Added useMinStars and useMaxInactivityMonths composables
- components/Sidebar.vue — Added filter dropdowns and clear button UI
- pages/index.vue — Added filtering and sorting logic
- pages/language/[slug].vue — Same filtering and sorting for language pages

## Testing
- Tested locally with bun dev
- Ran prettier --check — all files pass
- Ran nuxt build — build succeeds with no errors



Closes #2615