### PR TITLE
feat: add sort buttons for stars and last activity

### DIFF
--- a/components/SortButton.vue
+++ b/components/SortButton.vue
@@ -1,0 +1,19 @@
+<template>
+  <button
+    type="button"
+    @click="$emit('toggle')"
+    class="px-4 py-2 text-xs font-mono uppercase tracking-wider rounded border transition-all duration-200 mb-4 mr-2"
+    :class="active 
+      ? 'bg-juniper text-ink-400 border-juniper' 
+      : 'bg-ink-300 text-vanilla-300 border-ink-200 hover:border-juniper'"
+  >
+    <slot />
+  </button>
+</template>
+
+<script setup>
+defineProps({
+  active: Boolean
+})
+defineEmits(['toggle'])
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,51 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in Repositories" :key="repo.id" :repo="repo" />
+    <div class="flex flex-wrap gap-2">
+      <SortButton 
+        :active="sortType === 'stars'" 
+        @toggle="toggleSort('stars')"
+      >
+        {{ sortType === 'stars' ? 'Sorted by Stars' : 'Sort by Stars' }}
+      </SortButton>
+
+      <SortButton 
+        :active="sortType === 'activity'" 
+        @toggle="toggleSort('activity')"
+      >
+        {{ sortType === 'activity' ? 'Sorted by Last Activity' : 'Sort by Last Activity' }}
+      </SortButton>
+      
+    </div>
+    <RepoBox v-for="repo in sortedRepos" :key="repo.id" :repo="repo" />
   </div>
 </template>
 
 <script setup>
 import Repositories from '~/data/generated.json'
+
+
+const sortType = ref('none') 
+
+const sortedRepos = computed(() => {
+  let list = [...Repositories]
+  
+  if (sortType.value === 'stars') {
+    list.sort((a, b) => b.stars - a.stars)
+  } else if (sortType.value === 'activity') {
+    list.sort((a, b) => new Date(b.last_modified) - new Date(a.last_modified))
+  }
+  
+  return list
+})
+
+const toggleSort = (type) => {
+  if (sortType.value === type) {
+    sortType.value = 'none' 
+  } else {
+    sortType.value = type 
+  }
+}
+
 
 useHead({
   title: 'Good First Issue: Make your first open-source contribution',

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -1,6 +1,22 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
+    <div class="flex flex-wrap gap-2">
+      <SortButton 
+        :active="sortType === 'stars'" 
+        @toggle="toggleSort('stars')"
+      >
+        {{ sortType === 'stars' ? 'Sorted by Stars' : 'Sort by Stars' }}
+      </SortButton>
+
+      <SortButton 
+        :active="sortType === 'activity'" 
+        @toggle="toggleSort('activity')"
+      >
+        {{ sortType === 'activity' ? 'Sorted by Last Activity' : 'Sort by Last Activity' }}
+      </SortButton>
+    </div>
+
+    <RepoBox v-for="repo in sortedRepos" :key="repo.id" :repo="repo" />
   </div>
 </template>
 
@@ -13,6 +29,28 @@ const route = useRoute()
 const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
 
 const tag = Tags.find(t => t.slug === route.params.slug)
+
+const sortType = ref('none') 
+
+const sortedRepos = computed(() => {
+  let list = [...repositories]
+  
+  if (sortType.value === 'stars') {
+    list.sort((a, b) => b.stars - a.stars)
+  } else if (sortType.value === 'activity') {
+    list.sort((a, b) => new Date(b.last_modified) - new Date(a.last_modified))
+  }
+  
+  return list
+})
+
+const toggleSort = (type) => {
+  if (sortType.value === type) {
+    sortType.value = 'none' 
+  } else {
+    sortType.value = type 
+  }
+}
 
 useHead({
   title: `${tag.language} | Good First Issue`,


### PR DESCRIPTION
## Description
This PR introduces a new sorting functionality to the repository lists. It allows users to toggle between the default view and two new sorting modes:
1. **Popularity (Top Stars)**: Sorts repositories by star count in descending order.
2. **Freshness (Recent Activity)**: Sorts repositories by the last modified date, showing the most recently updated projects first.

## Why this is needed
The "Good First Issue" project aims to help new contributors find projects. By adding these sorting options, contributors can easily identify:
- **Reputable projects** that have high community trust (Top Stars).
- **Active projects** where maintainers are likely to respond quickly to new PRs (Recently Active).

## Changes
- **New Component**: Added `src/components/SortButton.vue`, a reusable, styled button component that follows the project's design system.
- **State Management**: Implemented `sortType` state using Vue's `ref`.
- **Sorting Logic**: Added `computed` properties in `index.vue` and `slug.vue` to handle reactive sorting without mutating the original data.

## Screenshots
| Default View |
<img width="2595" height="2102" alt="image" src="https://github.com/user-attachments/assets/8dfed78c-bb0e-4585-b68c-78240df783e3" />

| Sorted View |
<img width="2595" height="1672" alt="image" src="https://github.com/user-attachments/assets/772f5dd2-a811-4982-9732-8ce6759eff41" />

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked that the UI is responsive on mobile devices.
- [x] I have tested the sorting logic on both the index and language-specific pages.