### PR TITLE
Fix inaccurate issue count in repository cards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug or issue with Good First Issue
-title: "[Bug] "
+title: '[Bug] '
 labels: bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest a new feature or improvement
-title: "[Feature] "
+title: '[Feature] '
 labels: enhancement
 assignees: ''
 ---

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ You're welcome to add a new project to Good First Issue, and we encourage all pr
 
 To maintain the quality of projects in Good First Issue, please make sure your GitHub repository meets the following criteria:
 
-| Requirement | Description |
-|-------------|-------------|
-| Good First Issues | At least 3 open issues with beginner-friendly labels (`good first issue`, `beginner`, `easy`, `help wanted`, etc.) |
-| Contributors | At least 10 contributors |
-| README.md | Detailed setup instructions |
-| CONTRIBUTING.md | Guidelines for new contributors |
-| Active Maintenance | Recent commits and activity |
-| License | Valid open source license |
+| Requirement        | Description                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Good First Issues  | At least 3 open issues with beginner-friendly labels (`good first issue`, `beginner`, `easy`, `help wanted`, etc.) |
+| Contributors       | At least 10 contributors                                                                                           |
+| README.md          | Detailed setup instructions                                                                                        |
+| CONTRIBUTING.md    | Guidelines for new contributors                                                                                    |
+| Active Maintenance | Recent commits and activity                                                                                        |
+| License            | Valid open source license                                                                                          |
 
 Once your submission is reviewed and approved, it will be added to [goodfirstissue.dev](https://goodfirstissue.dev/).
 

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -18,6 +18,6 @@ import Tags from '~/data/tags.json'
 const route = useRoute()
 
 const activeTag = computed(() => {
-  return Tags.find(tag => tag.slug === route.params.slug)
+  return Tags.find((tag) => tag.slug === route.params.slug)
 })
 </script>

--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -45,7 +45,9 @@
     </div>
     <ol v-if="isCardOpen" class="px-5 py-3 text-base leading-loose border-t border-ink-200">
       <li v-for="issue in repo.issues" :key="issue.url" class="flex flex-row items-start justify-start py-1">
-        <span class="text-slate text-right px-2 leading-snug font-mono" style="min-width: 70px">#{{ issue.number }}</span>
+        <span class="text-slate text-right px-2 leading-snug font-mono" style="min-width: 70px"
+          >#{{ issue.number }}</span
+        >
         <div class="flex items-start flex-row flex-auto">
           <a
             title="Open issue on GitHub"
@@ -86,7 +88,7 @@ const props = defineProps({
 const openRepoId = useOpenRepoId()
 
 const issuesDisplay = computed(() => {
-  const numIssues = props.repo.issues.length
+  const numIssues = props.repo.issues_count
   return numIssues > 1 ? `${numIssues} issues` : `${numIssues} issue`
 })
 

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -35,11 +35,10 @@
         href="https://github.com/deepsourcelabs/good-first-issue#adding-a-new-project"
         target="_blank"
         rel="noopener noreferrer"
-        >
-          <PlusCircleIcon class="h-5 w-5 stroke-2" />
-          <span>Add your project</span>
-        </a
       >
+        <PlusCircleIcon class="h-5 w-5 stroke-2" />
+        <span>Add your project</span>
+      </a>
     </div>
 
     <div class="text-sm pt-6">
@@ -63,7 +62,7 @@
 <script setup>
 import Tags from '~/data/tags.json'
 import { PlusCircleIcon } from '@heroicons/vue/24/outline'
-import {HeartIcon} from '@heroicons/vue/24/solid'
+import { HeartIcon } from '@heroicons/vue/24/solid'
 </script>
 <style>
 .section-heading {

--- a/data/generated.sample.json
+++ b/data/generated.sample.json
@@ -82,7 +82,8 @@
         "comments_count": 0,
         "created_at": "2020-10-21T20:47:50+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "zulip",
@@ -167,7 +168,8 @@
         "comments_count": 3,
         "created_at": "2021-04-29T23:58:19+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "rubycritic",
@@ -238,7 +240,8 @@
         "comments_count": 5,
         "created_at": "2016-06-27T06:15:58+00:00"
       }
-    ]
+    ],
+    "issues_count": 8
   },
   {
     "name": "xenia",
@@ -323,7 +326,8 @@
         "comments_count": 2,
         "created_at": "2020-03-28T19:49:46+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "selene",
@@ -359,7 +363,8 @@
         "comments_count": 5,
         "created_at": "2021-04-11T10:40:10+00:00"
       }
-    ]
+    ],
+    "issues_count": 3
   },
   {
     "name": "react-trello-clone",
@@ -444,7 +449,8 @@
         "comments_count": 2,
         "created_at": "2021-05-23T19:23:34+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "weave",
@@ -508,7 +514,8 @@
         "comments_count": 0,
         "created_at": "2017-03-09T14:09:19+00:00"
       }
-    ]
+    ],
+    "issues_count": 7
   },
   {
     "name": "xterm.js",
@@ -593,7 +600,8 @@
         "comments_count": 2,
         "created_at": "2019-10-10T18:46:12+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "zeebe",
@@ -678,7 +686,8 @@
         "comments_count": 2,
         "created_at": "2017-09-27T12:33:55+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "yew",
@@ -728,7 +737,8 @@
         "comments_count": 2,
         "created_at": "2020-07-19T14:35:36+00:00"
       }
-    ]
+    ],
+    "issues_count": 5
   },
   {
     "name": "hint",
@@ -813,7 +823,8 @@
         "comments_count": 4,
         "created_at": "2019-09-27T18:19:42+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "gutenberg",
@@ -898,7 +909,8 @@
         "comments_count": 1,
         "created_at": "2021-05-10T16:10:38+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "wemake-python-styleguide",
@@ -969,7 +981,8 @@
         "comments_count": 2,
         "created_at": "2021-03-09T21:16:18+00:00"
       }
-    ]
+    ],
+    "issues_count": 8
   },
   {
     "name": "wpt",
@@ -1054,7 +1067,8 @@
         "comments_count": 0,
         "created_at": "2019-08-27T19:18:10+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "wordpress-seo",
@@ -1139,7 +1153,8 @@
         "comments_count": 2,
         "created_at": "2018-09-07T12:20:19+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "s3rs",
@@ -1161,7 +1176,8 @@
         "comments_count": 2,
         "created_at": "2019-10-21T07:55:11+00:00"
       }
-    ]
+    ],
+    "issues_count": 1
   },
   {
     "name": "zsh-syntax-highlighting",
@@ -1246,7 +1262,8 @@
         "comments_count": 4,
         "created_at": "2020-03-19T06:56:01+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "zaproxy",
@@ -1331,7 +1348,8 @@
         "comments_count": 15,
         "created_at": "2020-03-11T13:47:58+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "zephyr",
@@ -1416,7 +1434,8 @@
         "comments_count": 2,
         "created_at": "2020-09-02T11:38:33+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "WordPress-Android",
@@ -1487,7 +1506,8 @@
         "comments_count": 5,
         "created_at": "2019-12-10T19:50:24+00:00"
       }
-    ]
+    ],
+    "issues_count": 8
   },
   {
     "name": "zsh-completions",
@@ -1551,7 +1571,8 @@
         "comments_count": 0,
         "created_at": "2017-05-08T23:01:51+00:00"
       }
-    ]
+    ],
+    "issues_count": 7
   },
   {
     "name": "zio",
@@ -1636,7 +1657,8 @@
         "comments_count": 6,
         "created_at": "2020-11-09T12:57:23+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "wesnoth",
@@ -1721,7 +1743,8 @@
         "comments_count": 0,
         "created_at": "2021-05-08T18:46:17+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "hyper",
@@ -1792,7 +1815,8 @@
         "comments_count": 11,
         "created_at": "2018-04-15T19:04:04+00:00"
       }
-    ]
+    ],
+    "issues_count": 8
   },
   {
     "name": "winsw",
@@ -1849,7 +1873,8 @@
         "comments_count": 0,
         "created_at": "2020-07-26T04:54:35+00:00"
       }
-    ]
+    ],
+    "issues_count": 6
   },
   {
     "name": "WordPress-iOS",
@@ -1934,7 +1959,8 @@
         "comments_count": 2,
         "created_at": "2020-05-06T17:07:38+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "winston",
@@ -2005,7 +2031,8 @@
         "comments_count": 0,
         "created_at": "2017-01-19T13:22:08+00:00"
       }
-    ]
+    ],
+    "issues_count": 8
   },
   {
     "name": "woocommerce",
@@ -2090,7 +2117,8 @@
         "comments_count": 2,
         "created_at": "2021-05-16T07:51:44+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "next.js",
@@ -2175,7 +2203,8 @@
         "comments_count": 7,
         "created_at": "2021-03-06T12:45:53+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "yarn",
@@ -2260,7 +2289,8 @@
         "comments_count": 3,
         "created_at": "2018-05-29T08:40:15+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "html",
@@ -2345,7 +2375,8 @@
         "comments_count": 0,
         "created_at": "2019-11-18T16:27:09+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "fetch",
@@ -2381,7 +2412,8 @@
         "comments_count": 2,
         "created_at": "2020-08-18T14:13:55+00:00"
       }
-    ]
+    ],
+    "issues_count": 3
   },
   {
     "name": "yugabyte-db",
@@ -2466,7 +2498,8 @@
         "comments_count": 3,
         "created_at": "2021-03-15T16:02:37+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "data-science-notes",
@@ -2502,7 +2535,8 @@
         "comments_count": 0,
         "created_at": "2021-01-21T09:45:45+00:00"
       }
-    ]
+    ],
+    "issues_count": 3
   },
   {
     "name": "zeek",
@@ -2573,7 +2607,8 @@
         "comments_count": 7,
         "created_at": "2020-04-16T00:34:32+00:00"
       }
-    ]
+    ],
+    "issues_count": 8
   },
   {
     "name": "wger",
@@ -2609,7 +2644,8 @@
         "comments_count": 9,
         "created_at": "2016-11-15T12:28:57+00:00"
       }
-    ]
+    ],
+    "issues_count": 3
   },
   {
     "name": "spectrum",
@@ -2694,7 +2730,8 @@
         "comments_count": 13,
         "created_at": "2018-04-15T22:54:15+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "weblate",
@@ -2779,7 +2816,8 @@
         "comments_count": 5,
         "created_at": "2021-04-14T07:12:12+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   },
   {
     "name": "xunit",
@@ -2864,6 +2902,7 @@
         "comments_count": 3,
         "created_at": "2019-06-26T09:26:23+00:00"
       }
-    ]
+    ],
+    "issues_count": 10
   }
 ]

--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -92,10 +92,10 @@ class GitHubRateLimiter:
 
     def _update_rate_limit(self):
         try:
-            info = self._client.rate_limit()['resources']['core']
-            self._remaining = info['remaining']
-            self._reset_time = info['reset']
-            logger.debug("Rate limit: {}/{}", self._remaining, info['limit'])
+            info = self._client.rate_limit()["resources"]["core"]
+            self._remaining = info["remaining"]
+            self._reset_time = info["reset"]
+            logger.debug("Rate limit: {}/{}", self._remaining, info["limit"])
         except Exception as e:
             logger.warning("Failed to check rate limit: {}", e)
 
@@ -129,9 +129,7 @@ RepositoryInfo = Dict["str", Union[str, int, Sequence]]
 
 
 def get_repository_info(
-    identifier: RepositoryIdentifier,
-    client,
-    rate_limiter: GitHubRateLimiter
+    identifier: RepositoryIdentifier, client, rate_limiter: GitHubRateLimiter
 ) -> Optional[RepositoryInfo]:
     """Get the relevant information needed for the repository from its owner login and name."""
     owner, name = identifier["owner"], identifier["name"]
@@ -160,7 +158,7 @@ def get_repository_info(
                 issues_for_label = repository.issues(
                     labels=label,
                     state=ISSUE_STATE,
-                    number=ISSUE_LIMIT,
+                    number=-1,
                     sort=ISSUE_SORT,
                     direction=ISSUE_SORT_DIRECTION,
                 )
@@ -182,8 +180,11 @@ def get_repository_info(
                 info["id"] = str(repository.id)
 
                 # get the latest issues with the tag
+                all_issues = list(good_first_issues)
+                info["issues_count"] = len(all_issues)
+
                 issues = []
-                for issue in good_first_issues:
+                for issue in all_issues[:ISSUE_LIMIT]:
                     issues.append(
                         {
                             "title": issue.title,
@@ -203,11 +204,9 @@ def get_repository_info(
         except exceptions.ForbiddenError:
             rate_limiter.report_rate_limit_hit()
             if attempt < max_retries - 1:
-                logger.warning("Rate limited on {}/{}. Retrying after coordinated pause...",
-                             owner, name)
+                logger.warning("Rate limited on {}/{}. Retrying after coordinated pause...", owner, name)
             else:
-                logger.error("Rate limit exceeded after {} retries: {}/{}",
-                           max_retries, owner, name)
+                logger.error("Rate limit exceeded after {} retries: {}/{}", max_retries, owner, name)
                 return None
 
         except exceptions.NotFoundError:

--- a/gfi/test_data.py
+++ b/gfi/test_data.py
@@ -9,6 +9,7 @@ import toml
 
 DATA_FILE_PATH = "data/repositories.toml"
 LABELS_FILE_PATH = "data/labels.json"
+GENERATED_FILE_PATH = "data/generated.json"
 
 
 def _get_data_from_toml(file_path):
@@ -53,6 +54,19 @@ class TestDataSanity(unittest.TestCase):
         repos = data.get("repositories", [])
         print([item for item, count in Counter(repos).items() if count > 1])
         assert len(repos) == len(set(repos))
+
+    @staticmethod
+    def test_issues_count_field():
+        """Verify that each repo in generated.json has a valid issues_count field."""
+        if not os.path.exists(GENERATED_FILE_PATH):
+            return
+        data = _get_data_from_json(GENERATED_FILE_PATH)
+        for repo in data:
+            assert "issues_count" in repo, f"Missing issues_count in {repo.get('name')}"
+            assert isinstance(repo["issues_count"], int), f"issues_count is not int in {repo.get('name')}"
+            assert repo["issues_count"] >= len(repo["issues"]), (
+                f"issues_count < len(issues) in {repo.get('name')}"
+            )
 
 
 if __name__ == "__main__":

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,11 +17,11 @@ const route = useRoute()
 const tag = ref({})
 
 if (route.params.slug) {
-  tag.value = Tags.find(t => t.slug === route.params.slug)
+  tag.value = Tags.find((t) => t.slug === route.params.slug)
 }
 
 useHead({
-  charset: "utf-8",
+  charset: 'utf-8',
   link: [
     {
       rel: 'apple-touch-icon',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,10 +10,11 @@ import Repositories from '~/data/generated.json'
 useHead({
   title: 'Good First Issue: Make your first open-source contribution',
   meta: [
-  {
-    name: 'description',
-    content: 'Making your first open-source contribution is easier than you think. Good First Issue is a curated list of issues from popular open-source projects that you can easily fix. Start today!'
-  }
+    {
+      name: 'description',
+      content:
+        'Making your first open-source contribution is easier than you think. Good First Issue is a curated list of issues from popular open-source projects that you can easily fix. Start today!'
+    }
   ]
 })
 </script>

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -10,15 +10,17 @@ import Tags from '~/data/tags.json'
 
 const route = useRoute()
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const repositories = Repositories.filter((repository) => repository.slug === route.params.slug)
 
-const tag = Tags.find(t => t.slug === route.params.slug)
+const tag = Tags.find((t) => t.slug === route.params.slug)
 
 useHead({
   title: `${tag.language} | Good First Issue`,
-  meta: [{
-    name: 'description',
-    content: `Curated list of issues in ${tag.language} from popular open-source projects that you can easily fix.`
-  }]
+  meta: [
+    {
+      name: 'description',
+      content: `Curated list of issues in ${tag.language} from popular open-source projects that you can easily fix.`
+    }
+  ]
 })
 </script>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,11 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#33cb9a","background_color":"#16181d","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "theme_color": "#33cb9a",
+  "background_color": "#16181d",
+  "display": "standalone"
+}

--- a/sync.js
+++ b/sync.js
@@ -74,9 +74,9 @@ async function syncFilesDown() {
   }
 }
 
-if (!("BLOB_READ_WRITE_TOKEN" in process.env)) {
+if (!('BLOB_READ_WRITE_TOKEN' in process.env)) {
   console.error('`BLOB_READ_WRITE_TOKEN` not set in env. exiting.')
-  process.exit(1)  // skicq: JS-0263
+  process.exit(1) // skicq: JS-0263
 }
 
 switch (process.argv[2]) {


### PR DESCRIPTION
## Problem

The issue count badge on repository cards always showed the number of
fetched issues (capped at `ISSUE_LIMIT=10`) instead of the real count
of good first issues available on GitHub.

## Changes

- **populate.py**: Removed `number=ISSUE_LIMIT` cap from
  `repository.issues()` so all matching issues are fetched. Computed the
  real total with `len()` before slicing and stored it as `issues_count`
  in the generated JSON. The `issues` array is still sliced to
  `ISSUE_LIMIT` for display.
- **RepoBox.vue**: Updated `issuesDisplay` computed property to use
  `repo.issues_count` instead of `repo.issues.length`.
- **test_data.py**: Added `test_issues_count_field` to validate
  presence, type, and consistency of the new field.
- **generated.sample.json**: Added `issues_count` to all sample entries.

## How to test

```bash
cp data/generated.sample.json data/generated.json
uv run python gfi/test_data.py -v   # 6 tests should pass
bun dev                              # verify badge shows issues_count
```

## AI disclosure
GitHub Copilot Chat was used to assist in analyzing the root cause of
the bug and generating code suggestions for the fix. All suggestions
were reviewed, validated, and tested manually before applying.

## Notes for maintainers
After merging, run make generate to regenerate generated.json with
the new issues_count field. Without regeneration, the frontend will
show undefined in the badge.

Removing the number cap means github3.py will now paginate through
all matching issues per label, which increases API calls. The existing
rate limiter handles this — no changes needed there.

Fixes #2561