### PR TITLE
add encode/django-rest-framework to repositories

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -572,6 +572,7 @@ repositories = [
   'github.com/pygame/pygame',
   'github.com/pyinstaller/pyinstaller',
   'github.com/pypa/pip',
+  'github.com/encode/django-rest-framework',
   'github.com/pypa/pipenv',
   'github.com/pypa/warehouse',
   'github.com/pyqtgraph/pyqtgraph',


### PR DESCRIPTION
Added the encode/django-rest-framework Python REST API framework to the repositories list
