### PR TITLE
Refactor: remove duplicate file loading logic in test_data.py

### DIFF
--- a/gfi/test_data.py
+++ b/gfi/test_data.py
@@ -19,6 +19,13 @@ def _get_data_from_toml(file_path):
 def _get_data_from_json(file_path):
     with open(file_path, "r") as file_desc:
         return json.load(file_desc)
+    
+def _get_data(file_path):
+    with open(file_path, "r") as file_desc:
+        if file_path.endswith(".json"):
+            return json.load(file_desc)
+        elif file_path.endswith(".toml"):
+            return toml.load(file_desc)
 
 
 class TestDataSanity(unittest.TestCase):
@@ -37,19 +44,19 @@ class TestDataSanity(unittest.TestCase):
     @staticmethod
     def test_data_file_sane():
         """Verify that the file is a valid TOML with required data."""
-        data = _get_data_from_toml(DATA_FILE_PATH)
+        data = _get_data(DATA_FILE_PATH)
         assert "repositories" in data
 
     @staticmethod
     def test_labels_file_sane():
         """Verify that the labels file is a valid JSON"""
-        data = _get_data_from_json(LABELS_FILE_PATH)
+        data = _get_data(LABELS_FILE_PATH)
         assert "labels" in data
 
     @staticmethod
     def test_no_duplicates():
         """Verify that all entries are unique."""
-        data = _get_data_from_toml(DATA_FILE_PATH)
+        data = _get_data(DATA_FILE_PATH)
         repos = data.get("repositories", [])
         print([item for item, count in Counter(repos).items() if count > 1])
         assert len(repos) == len(set(repos))


### PR DESCRIPTION
Refactored duplicate file loading logic in test_data.py by using a single helper function to handle both JSON and TOML files.