### PR TITLE
Add React repository to repositories.toml

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -830,3 +830,7 @@ repositories = [
   'github.com/zsh-users/zsh-syntax-highlighting',
   'github.com/zulip/zulip',
 ]
+[[repositories]]
+name = "facebook/react"
+url = "https://github.com/facebook/react"
+description = "A JavaScript library for building user interfaces"


### PR DESCRIPTION
Added a new repository entry for facebook/react in data/repositories.toml.

This repository is widely used and beginner-friendly, with good documentation and active community support.

This change helps improve the list of curated projects available for new contributors.