### PR TITLE
Add supabase-py repository to the list

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -682,6 +682,7 @@ repositories = [
   'github.com/spotify/backstage',
   'github.com/spotify/scio',
   'github.com/square/retrofit',
+  'github.com/supabase/supabase-py',
   'github.com/SSENSE/vue-carousel',
   'github.com/StackStorm/st2',
   'github.com/stan-dev/stan',


### PR DESCRIPTION
- Added supabase/supabase-py to data/repositories.toml
- Repository meets all criteria:
  - Has good first issues
  - Has multiple contributors
  - Has README and CONTRIBUTING.md
  - Actively maintained

Issues link: https://github.com/supabase/supabase-py/issues