### PR TITLE
Added feature Filter repositories by stars and last activity

### DIFF
--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -30,6 +30,44 @@
       </div>
     </div>
     <div class="pt-6">
+      <h3 class="section-heading">Filter</h3>
+      <div class="space-y-3">
+        <div>
+          <label class="text-xs text-slate uppercase tracking-wider block mb-1">Min Stars</label>
+          <select
+            v-model.number="minStars"
+            class="w-full bg-ink-300 border border-ink-200 text-vanilla-300 text-sm rounded-sm px-2 py-1 focus:outline-none focus:border-juniper"
+          >
+            <option :value="0">Any</option>
+            <option :value="100">100+</option>
+            <option :value="1000">1,000+</option>
+            <option :value="5000">5,000+</option>
+            <option :value="10000">10,000+</option>
+          </select>
+        </div>
+        <div>
+          <label class="text-xs text-slate uppercase tracking-wider block mb-1">Last Activity</label>
+          <select
+            v-model.number="maxAgeDays"
+            class="w-full bg-ink-300 border border-ink-200 text-vanilla-300 text-sm rounded-sm px-2 py-1 focus:outline-none focus:border-juniper"
+          >
+            <option :value="0">Any time</option>
+            <option :value="30">Last 30 days</option>
+            <option :value="90">Last 3 months</option>
+            <option :value="180">Last 6 months</option>
+            <option :value="365">Last year</option>
+          </select>
+        </div>
+        <button
+          v-if="minStars > 0 || maxAgeDays > 0"
+          class="text-xs text-slate hover:text-juniper"
+          @click="minStars = 0; maxAgeDays = 0"
+        >
+          Reset filters
+        </button>
+      </div>
+    </div>
+    <div class="pt-6">
       <a
         class="bg-juniper hover:bg-light_juniper text-ink-400 uppercase rounded-md font-bold text-center px-1 py-3 flex flex-row items-center justify-center space-x-1"
         href="https://github.com/deepsourcelabs/good-first-issue#adding-a-new-project"
@@ -63,7 +101,10 @@
 <script setup>
 import Tags from '~/data/tags.json'
 import { PlusCircleIcon } from '@heroicons/vue/24/outline'
-import {HeartIcon} from '@heroicons/vue/24/solid'
+import { HeartIcon } from '@heroicons/vue/24/solid'
+
+const minStars = useMinStars()
+const maxAgeDays = useMaxAgeDays()
 </script>
 <style>
 .section-heading {

--- a/composables/states.js
+++ b/composables/states.js
@@ -1,1 +1,3 @@
 export const useOpenRepoId = () => useState('openRepoId', () => null)
+export const useMinStars = () => useState('minStars', () => 0)
+export const useMaxAgeDays = () => useState('maxAgeDays', () => 0)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,38 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in Repositories" :key="repo.id" :repo="repo" />
+    <p v-if="repositories.length === 0" class="text-slate text-sm py-8 text-center">
+      No repositories match the selected filters.
+    </p>
+    <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
   </div>
 </template>
 
 <script setup>
-import Repositories from '~/data/generated.json'
+import AllRepositories from '~/data/generated.json'
+
+const minStars = useMinStars()
+const maxAgeDays = useMaxAgeDays()
+
+const repositories = computed(() => {
+  let repos = [...AllRepositories]
+
+  if (minStars.value > 0) {
+    repos = repos.filter(r => r.stars >= minStars.value)
+  }
+
+  if (maxAgeDays.value > 0) {
+    const cutoff = Date.now() - maxAgeDays.value * 24 * 60 * 60 * 1000
+    repos = repos.filter(r => new Date(r.last_modified).getTime() >= cutoff)
+  }
+
+  if (minStars.value > 0) {
+    repos = [...repos].sort((a, b) => b.stars - a.stars)
+  } else if (maxAgeDays.value > 0) {
+    repos = [...repos].sort((a, b) => new Date(b.last_modified) - new Date(a.last_modified))
+  }
+
+  return repos
+})
 
 useHead({
   title: 'Good First Issue: Make your first open-source contribution',

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -1,5 +1,8 @@
 <template>
   <div class="p-4 w-full">
+    <p v-if="repositories.length === 0" class="text-slate text-sm py-8 text-center">
+      No repositories match the selected filters.
+    </p>
     <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
   </div>
 </template>
@@ -9,8 +12,29 @@ import Repositories from '~/data/generated.json'
 import Tags from '~/data/tags.json'
 
 const route = useRoute()
+const minStars = useMinStars()
+const maxAgeDays = useMaxAgeDays()
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const repositories = computed(() => {
+  let repos = Repositories.filter(r => r.slug === route.params.slug)
+
+  if (minStars.value > 0) {
+    repos = repos.filter(r => r.stars >= minStars.value)
+  }
+
+  if (maxAgeDays.value > 0) {
+    const cutoff = Date.now() - maxAgeDays.value * 24 * 60 * 60 * 1000
+    repos = repos.filter(r => new Date(r.last_modified).getTime() >= cutoff)
+  }
+
+  if (minStars.value > 0) {
+    repos = [...repos].sort((a, b) => b.stars - a.stars)
+  } else if (maxAgeDays.value > 0) {
+    repos = [...repos].sort((a, b) => new Date(b.last_modified) - new Date(a.last_modified))
+  }
+
+  return repos
+})
 
 const tag = Tags.find(t => t.slug === route.params.slug)
 


### PR DESCRIPTION
## Feature: Filter repositories by stars and last activity

### Overview

Adds filtering functionality to allow users to refine repositories based on number of stars and recent activity, along with the existing language filter.



### Solution

* Added filter for minimum stars
* Added filter for recent activity (e.g., last commit within a given timeframe)
* Enabled combination with existing language filter

Users can now filter by stars, activity, or both.

### Impact

Improves discoverability by helping users find relevant, popular, and actively maintained repositories more efficiently.

### Testing

Verified filters work individually and in combination, and ensured existing functionality remains unaffected.
