### PR TITLE
Remove incorrect await from synchronous fs functions

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -55,10 +55,10 @@ function downloadFile(url, dest) {
 async function syncFilesUp() {
   for (const fileName of filesToSync) {
     const filePath = path.resolve(path.join(dirToSync, fileName))
-    const stat = await fs.statSync(filePath)
+    const stat = fs.statSync(filePath)
 
     if (stat.isFile()) {
-      const fileContent = await fs.readFileSync(filePath)
+      const fileContent = fs.readFileSync(filePath)
       await put(fileName, fileContent, { access: 'public', addRandomSuffix: false })
     }
   }


### PR DESCRIPTION
This PR removes incorrect await keywords from synchronous file system operations in sync.js.

The await keyword should not be used with fs.statSync() and fs.readFileSync() as these are synchronous functions that do not return Promises.

Changes:
- Remove await from fs.statSync() call  
- Remove await from fs.readFileSync() call