### PR TITLE
Filter repositories by stars and last activity

### DIFF
--- a/components/RepoBox.vue
+++ b/components/RepoBox.vue
@@ -44,7 +44,7 @@
       </div>
     </div>
     <ol v-if="isCardOpen" class="px-5 py-3 text-base leading-loose border-t border-ink-200">
-      <li v-for="issue in repo.issues" :key="issue.url" class="flex flex-row items-start justify-start py-1">
+      <li v-for="issue in sortedIssues" :key="issue.url" class="flex flex-row items-start justify-start py-1">
         <span class="text-slate text-right px-2 leading-snug font-mono" style="min-width: 70px">#{{ issue.number }}</span>
         <div class="flex items-start flex-row flex-auto">
           <a
@@ -86,7 +86,7 @@ const props = defineProps({
 const openRepoId = useOpenRepoId()
 
 const issuesDisplay = computed(() => {
-  const numIssues = props.repo.issues.length
+  const numIssues = sortedIssues.value.length
   return numIssues > 1 ? `${numIssues} issues` : `${numIssues} issue`
 })
 
@@ -96,6 +96,12 @@ const lastModifiedDisplay = computed(() => {
 
 const isCardOpen = computed(() => {
   return openRepoId.value === props.repo.id
+})
+
+const sortedIssues = computed(() => {
+  return [...props.repo.issues].sort((a, b) =>
+    new Date(b.created_at) - new Date(a.created_at)
+  )
 })
 
 function toggle(repoId) {

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -29,6 +29,38 @@
         >
       </div>
     </div>
+    <div v-if="$route.params.slug" class="pt-6">
+      <h3 class="section-heading">Filter repositories</h3>
+      <div class="mb-4">
+        <label class="text-xs font-semibold text-slate uppercase mb-2 block">Minimum stars</label>
+        <select
+          v-model.number="starsFilter"
+          class="w-full px-3 py-2 rounded-md bg-ink-400 text-vanilla-300 border border-ink-200 hover:border-juniper focus:outline-none focus:border-juniper"
+        >
+          <option :value="0">Any</option>
+          <option :value="10">10+</option>
+          <option :value="50">50+</option>
+          <option :value="100">100+</option>
+          <option :value="500">500+</option>
+          <option :value="1000">1K+</option>
+          <option :value="5000">5K+</option>
+          <option :value="10000">10K+</option>
+        </select>
+      </div>
+      <div>
+        <label class="text-xs font-semibold text-slate uppercase mb-2 block">Last activity (months ago)</label>
+        <select
+          v-model.number="activityFilter"
+          class="w-full px-3 py-2 rounded-md bg-ink-400 text-vanilla-300 border border-ink-200 hover:border-juniper focus:outline-none focus:border-juniper"
+        >
+          <option :value="null">Any</option>
+          <option :value="1">Last month</option>
+          <option :value="3">Last 3 months</option>
+          <option :value="6">Last 6 months</option>
+          <option :value="12">Last year</option>
+        </select>
+      </div>
+    </div>
     <div class="pt-6">
       <a
         class="bg-juniper hover:bg-light_juniper text-ink-400 uppercase rounded-md font-bold text-center px-1 py-3 flex flex-row items-center justify-center space-x-1"
@@ -64,6 +96,9 @@
 import Tags from '~/data/tags.json'
 import { PlusCircleIcon } from '@heroicons/vue/24/outline'
 import {HeartIcon} from '@heroicons/vue/24/solid'
+
+const starsFilter = useStarsFilter()
+const activityFilter = useActivityFilter()
 </script>
 <style>
 .section-heading {

--- a/components/Sidebar.vue
+++ b/components/Sidebar.vue
@@ -29,7 +29,7 @@
         >
       </div>
     </div>
-    <div v-if="$route.params.slug" class="pt-6">
+    <div class="pt-6">
       <h3 class="section-heading">Filter repositories</h3>
       <div class="mb-4">
         <label class="text-xs font-semibold text-slate uppercase mb-2 block">Minimum stars</label>
@@ -47,19 +47,41 @@
           <option :value="10000">10K+</option>
         </select>
       </div>
-      <div>
-        <label class="text-xs font-semibold text-slate uppercase mb-2 block">Last activity (months ago)</label>
+      <div class="mb-4">
+        <label class="text-xs font-semibold text-slate uppercase mb-2 block">Last activity</label>
         <select
           v-model.number="activityFilter"
           class="w-full px-3 py-2 rounded-md bg-ink-400 text-vanilla-300 border border-ink-200 hover:border-juniper focus:outline-none focus:border-juniper"
         >
-          <option :value="null">Any</option>
-          <option :value="1">Last month</option>
-          <option :value="3">Last 3 months</option>
-          <option :value="6">Last 6 months</option>
-          <option :value="12">Last year</option>
+          <option :value="null">Any time</option>
+          <option :value="1">Last day</option>
+          <option :value="7">Last week</option>
+          <option :value="30">Last month</option>
+          <option :value="90">Last 3 months</option>
+          <option :value="180">Last 6 months</option>
+          <option :value="365">Last year</option>
         </select>
       </div>
+      <div class="mb-4">
+        <label class="text-xs font-semibold text-slate uppercase mb-2 block">Good first issues</label>
+        <select
+          v-model="issueCountFilter"
+          class="w-full px-3 py-2 rounded-md bg-ink-400 text-vanilla-300 border border-ink-200 hover:border-juniper focus:outline-none focus:border-juniper"
+        >
+          <option :value="null">All issues</option>
+          <option value="1-3">1-3 issues</option>
+          <option value="4-10">4-10 issues</option>
+          <option value="11-20">11-20 issues</option>
+          <option value="20+">20+ issues</option>
+        </select>
+      </div>
+      <button
+        v-if="starsFilter > 0 || activityFilter || issueCountFilter"
+        class="text-xs text-slate hover:text-juniper transition-colors"
+        @click="resetFilters"
+      >
+        ✕ Reset filters
+      </button>
     </div>
     <div class="pt-6">
       <a
@@ -99,6 +121,13 @@ import {HeartIcon} from '@heroicons/vue/24/solid'
 
 const starsFilter = useStarsFilter()
 const activityFilter = useActivityFilter()
+const issueCountFilter = useIssueCountFilter()
+
+const resetFilters = () => {
+  starsFilter.value = 0
+  activityFilter.value = null
+  issueCountFilter.value = null
+}
 </script>
 <style>
 .section-heading {

--- a/composables/states.js
+++ b/composables/states.js
@@ -1,1 +1,3 @@
 export const useOpenRepoId = () => useState('openRepoId', () => null)
+export const useStarsFilter = () => useState('starsFilter', () => 0)  // minimum stars
+export const useActivityFilter = () => useState('activityFilter', () => null)  // months threshold

--- a/composables/states.js
+++ b/composables/states.js
@@ -1,3 +1,4 @@
 export const useOpenRepoId = () => useState('openRepoId', () => null)
 export const useStarsFilter = () => useState('starsFilter', () => 0)  // minimum stars
-export const useActivityFilter = () => useState('activityFilter', () => null)  // months threshold
+export const useActivityFilter = () => useState('activityFilter', () => null)  // days threshold
+export const useIssueCountFilter = () => useState('issueCountFilter', () => null)  // '1-3', '4-10', '11-20', '20+'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,78 @@
 <template>
   <div class="p-4 w-full">
-    <RepoBox v-for="repo in Repositories" :key="repo.id" :repo="repo" />
+    <div v-if="repositories.length === 0" class="text-center py-8">
+      <p class="text-vanilla-400">No repositories match the selected filters.</p>
+    </div>
+    <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
   </div>
 </template>
 
 <script setup>
 import Repositories from '~/data/generated.json'
+import dayjs from 'dayjs'
+
+const starsFilter = useStarsFilter()
+const activityFilter = useActivityFilter()
+const issueCountFilter = useIssueCountFilter()
+
+const repositories = computed(() => {
+  let filtered = [...Repositories]
+
+  // Filter by minimum stars
+  if (starsFilter.value > 0) {
+    filtered = filtered.filter(repo => repo.stars >= starsFilter.value)
+  }
+
+  // Filter by last activity (in days)
+  if (activityFilter.value !== null && activityFilter.value !== undefined) {
+    const cutoffDate = dayjs().subtract(activityFilter.value, 'days')
+    filtered = filtered.filter(repo => dayjs(repo.last_modified).isAfter(cutoffDate))
+  }
+
+  // Filter by issue count
+  if (issueCountFilter.value) {
+    filtered = filtered.filter(repo => {
+      const count = repo.issues.length
+      switch (issueCountFilter.value) {
+        case '1-3':
+          return count >= 1 && count <= 3
+        case '4-10':
+          return count >= 4 && count <= 10
+        case '11-20':
+          return count >= 11 && count <= 20
+        case '20+':
+          return count >= 20
+        default:
+          return true
+      }
+    })
+  }
+
+  // Implicit smart sorting
+  // Prioritize sorting by whichever filter user selected
+  if (issueCountFilter.value) {
+    // User filtered by issues → show most opportunities first
+    return filtered.sort((a, b) => b.issues.length - a.issues.length)
+  } else if (starsFilter.value > 0) {
+    // User filtered by stars → show most popular first
+    return filtered.sort((a, b) => b.stars - a.stars)
+  } else if (activityFilter.value !== null && activityFilter.value !== undefined) {
+    // User filtered by activity → show most recent first
+    return filtered.sort((a, b) => new Date(b.last_modified) - new Date(a.last_modified))
+  } else {
+    // Default: balance all factors - stars → recency → issues
+    const sorted = filtered.sort((a, b) => {
+      const starDiff = b.stars - a.stars
+      if (starDiff !== 0) return starDiff
+
+      const recencyDiff = new Date(b.last_modified) - new Date(a.last_modified)
+      if (recencyDiff !== 0) return recencyDiff
+
+      return b.issues.length - a.issues.length
+    })
+    return sorted
+  }
+})
 
 useHead({
   title: 'Good First Issue: Make your first open-source contribution',

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -1,5 +1,8 @@
 <template>
   <div class="p-4 w-full">
+    <div v-if="repositories.length === 0" class="text-center py-8">
+      <p class="text-vanilla-400">No repositories match the selected filters.</p>
+    </div>
     <RepoBox v-for="repo in repositories" :key="repo.id" :repo="repo" />
   </div>
 </template>
@@ -7,10 +10,29 @@
 <script setup>
 import Repositories from '~/data/generated.json'
 import Tags from '~/data/tags.json'
+import dayjs from 'dayjs'
 
 const route = useRoute()
+const starsFilter = useStarsFilter()
+const activityFilter = useActivityFilter()
 
-const repositories = Repositories.filter(repository => repository.slug === route.params.slug)
+const repositories = computed(() => {
+  let filtered = Repositories.filter(repository => repository.slug === route.params.slug)
+
+  // Filter by minimum stars
+  if (starsFilter.value > 0) {
+    filtered = filtered.filter(repo => repo.stars >= starsFilter.value)
+  }
+
+  // Filter by last activity (in months)
+  if (activityFilter.value !== null && activityFilter.value !== undefined) {
+    const cutoffDate = dayjs().subtract(activityFilter.value, 'months')
+    filtered = filtered.filter(repo => dayjs(repo.last_modified).isAfter(cutoffDate))
+  }
+
+  // Sort by stars (descending) as secondary sort
+  return filtered.sort((a, b) => b.stars - a.stars)
+})
 
 const tag = Tags.find(t => t.slug === route.params.slug)
 

--- a/pages/language/[slug].vue
+++ b/pages/language/[slug].vue
@@ -15,6 +15,7 @@ import dayjs from 'dayjs'
 const route = useRoute()
 const starsFilter = useStarsFilter()
 const activityFilter = useActivityFilter()
+const issueCountFilter = useIssueCountFilter()
 
 const repositories = computed(() => {
   let filtered = Repositories.filter(repository => repository.slug === route.params.slug)
@@ -24,14 +25,55 @@ const repositories = computed(() => {
     filtered = filtered.filter(repo => repo.stars >= starsFilter.value)
   }
 
-  // Filter by last activity (in months)
+  // Filter by last activity (in days)
   if (activityFilter.value !== null && activityFilter.value !== undefined) {
-    const cutoffDate = dayjs().subtract(activityFilter.value, 'months')
+    const cutoffDate = dayjs().subtract(activityFilter.value, 'days')
     filtered = filtered.filter(repo => dayjs(repo.last_modified).isAfter(cutoffDate))
   }
 
-  // Sort by stars (descending) as secondary sort
-  return filtered.sort((a, b) => b.stars - a.stars)
+  // Filter by issue count
+  if (issueCountFilter.value) {
+    filtered = filtered.filter(repo => {
+      const count = repo.issues.length
+      switch (issueCountFilter.value) {
+        case '1-3':
+          return count >= 1 && count <= 3
+        case '4-10':
+          return count >= 4 && count <= 10
+        case '11-20':
+          return count >= 11 && count <= 20
+        case '20+':
+          return count >= 20
+        default:
+          return true
+      }
+    })
+  }
+
+  // Implicit smart sorting
+  // Prioritize sorting by whichever filter user selected
+  if (issueCountFilter.value) {
+    // User filtered by issues → show most opportunities first
+    return filtered.sort((a, b) => b.issues.length - a.issues.length)
+  } else if (starsFilter.value > 0) {
+    // User filtered by stars → show most popular first
+    return filtered.sort((a, b) => b.stars - a.stars)
+  } else if (activityFilter.value !== null && activityFilter.value !== undefined) {
+    // User filtered by activity → show most recent first
+    return filtered.sort((a, b) => new Date(b.last_modified) - new Date(a.last_modified))
+  } else {
+    // Default: balance all factors - stars → recency → issues
+    const sorted = filtered.sort((a, b) => {
+      const starDiff = b.stars - a.stars
+      if (starDiff !== 0) return starDiff
+      
+      const recencyDiff = new Date(b.last_modified) - new Date(a.last_modified)
+      if (recencyDiff !== 0) return recencyDiff
+      
+      return b.issues.length - a.issues.length
+    })
+    return sorted
+  }
 })
 
 const tag = Tags.find(t => t.slug === route.params.slug)


### PR DESCRIPTION
## Description
Add filtering and sorting for repositories by stars, activity, and issue count.

## Features
- **Filter by stars**: 10+, 50+, 100+, 500+, 1K+, 5K+, 10K+
- **Filter by activity**: Last day, week, month, 3 months, 6 months, year
- **Filter by issue count**: 1-3 issues, 4-10 issues, 11-20 issues, 20+ issues
- **Sorting**: Automatically sorts by what user filters (stars → popularity, activity → recency, issues → opportunities)
- **Issues sorted newest first** when expanded
- **Reset button** to clear all filters
- Works on both index page and language pages

## Testing
-  All filters work independently and together
-  Empty state message when no results
-  Sorting works correctly
-  Reset button clears filters
- Existing tests work correctly

## AI Disclosure
Built with GitHub Copilot assistance. I've reviewed all code and fully understand the implementation.

## Notes for Reviewers
This is my first open-source contribution! I really appreciate any feedback or suggestions for improvement, whether the PR gets merged or not. It's been a great learning experience working on this feature.

I noticed there's another similar PR (#2657). I developed this independently before seeing theirs, but I'm happy if the maintainers decide that approach works better. Looking forward to learning from the review process!

## Screenshots of the changes

<img width="1445" height="818" alt="image" src="https://github.com/user-attachments/assets/69ebc567-5f27-4eba-9a87-b1964fbc6efa" />
<img width="483" height="807" alt="image" src="https://github.com/user-attachments/assets/e21eb4b7-823c-4234-9f9c-128071c57c9f" />
<img width="486" height="815" alt="image" src="https://github.com/user-attachments/assets/ad5fef93-279a-4e68-8e09-853d186e4a6b" />
<img width="474" height="813" alt="image" src="https://github.com/user-attachments/assets/36019d29-0f60-42fc-8407-60f72be27538" />
