### PR TITLE
Remove no-op await on synchronous fs calls in sync.js

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -55,10 +55,10 @@ function downloadFile(url, dest) {
 async function syncFilesUp() {
   for (const fileName of filesToSync) {
     const filePath = path.resolve(path.join(dirToSync, fileName))
-    const stat = await fs.statSync(filePath)
+    const stat = fs.statSync(filePath)
 
     if (stat.isFile()) {
-      const fileContent = await fs.readFileSync(filePath)
+      const fileContent = fs.readFileSync(filePath)
       await put(fileName, fileContent, { access: 'public', addRandomSuffix: false })
     }
   }


### PR DESCRIPTION
## Summary
- Removed await from fs.statSync() and fs.readFileSync() calls in syncFilesUp()

### Problem
fs.statSync and fs.readFileSync are synchronous functions that return values directly, not Promises. The await keyword before them is a no-op and misleading. The async await put(...) call (Vercel Blob API) remains unchanged as it is genuinely async.

## Test plan
- [x] bun run build succeeds
- [x] Verified sync.js logic is unchanged (only removed misleading await keywords)