### PR TITLE
Improve data sanity tests

### DIFF
--- a/gfi/test_data.py
+++ b/gfi/test_data.py
@@ -4,55 +4,62 @@ import json
 import os
 import unittest
 from collections import Counter
+from pathlib import Path
+from typing import Any
 
-import toml
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+    import toml
 
-DATA_FILE_PATH = "data/repositories.toml"
-LABELS_FILE_PATH = "data/labels.json"
+DATA_FILE_PATH = Path("data/repositories.toml")
+LABELS_FILE_PATH = Path("data/labels.json")
 
 
-def _get_data_from_toml(file_path):
-    with open(file_path, "r") as file_desc:
+def _get_data_from_toml(file_path: Path) -> Any:
+    if tomllib is not None:
+        with file_path.open("rb") as file_desc:
+            return tomllib.load(file_desc)
+
+    with file_path.open("r", encoding="utf-8") as file_desc:
         return toml.load(file_desc)
 
 
-def _get_data_from_json(file_path):
-    with open(file_path, "r") as file_desc:
+def _get_data_from_json(file_path: Path) -> Any:
+    with file_path.open("r", encoding="utf-8") as file_desc:
         return json.load(file_desc)
 
 
 class TestDataSanity(unittest.TestCase):
     """Test for sanity of the data file."""
 
-    @staticmethod
-    def test_data_file_exists():
+    def test_data_file_exists(self):
         """Verify that the data file exists."""
-        assert os.path.exists(DATA_FILE_PATH)
+        self.assertTrue(os.path.exists(DATA_FILE_PATH), f"Expected {DATA_FILE_PATH} to exist")
 
-    @staticmethod
-    def test_labels_file_exists():
+    def test_labels_file_exists(self):
         """Verify that the labels file exists."""
-        assert os.path.exists(LABELS_FILE_PATH)
+        self.assertTrue(os.path.exists(LABELS_FILE_PATH), f"Expected {LABELS_FILE_PATH} to exist")
 
-    @staticmethod
-    def test_data_file_sane():
+    def test_data_file_sane(self):
         """Verify that the file is a valid TOML with required data."""
         data = _get_data_from_toml(DATA_FILE_PATH)
-        assert "repositories" in data
+        self.assertIn("repositories", data)
+        self.assertIsInstance(data["repositories"], list)
 
-    @staticmethod
-    def test_labels_file_sane():
-        """Verify that the labels file is a valid JSON"""
+    def test_labels_file_sane(self):
+        """Verify that the labels file is a valid JSON."""
         data = _get_data_from_json(LABELS_FILE_PATH)
-        assert "labels" in data
+        self.assertIn("labels", data)
+        self.assertIsInstance(data["labels"], list)
 
-    @staticmethod
-    def test_no_duplicates():
+    def test_no_duplicates(self):
         """Verify that all entries are unique."""
         data = _get_data_from_toml(DATA_FILE_PATH)
         repos = data.get("repositories", [])
-        print([item for item, count in Counter(repos).items() if count > 1])
-        assert len(repos) == len(set(repos))
+        duplicates = [item for item, count in Counter(repos).items() if count > 1]
+        self.assertEqual([], duplicates, f"Found duplicate repository entries: {duplicates}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean up the data sanity tests in gfi/test_data.py
- use clearer unittest assertions and stronger type checks for the loaded data
- remove the debug print in the duplicate check
- use 	omllib when available, with a fallback to 	oml, so TOML loading works across Python versions with fewer runtime dependencies

## Why
Issue #2273 calls out duplicated file-loading logic, weak assertions, and limited robustness in the data tests. This keeps the scope limited to the existing test file while making failures clearer and the TOML loading path more resilient.

## Testing
- ran C:\Users\jumax\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe gfi\\test_data.py
- all 5 tests passed

## AI usage disclosure
I used AI assistance to help draft and review this change, and I manually checked the diff and test output before submitting.