### PR TITLE
fix: filter out pull requests from issues count (#2561)

### DIFF
--- a/gfi/populate.py
+++ b/gfi/populate.py
@@ -165,7 +165,7 @@ def get_repository_info(
                     direction=ISSUE_SORT_DIRECTION,
                 )
                 good_first_issues.update(issues_for_label)
-            logger.info("\t found {} good first issues", len(good_first_issues))
+            logger.info("\t processing {} potential issues/pull requests", len(good_first_issues))
             # check if repo has at least one good first issue
             if good_first_issues and repository.language:
                 # store the repo info
@@ -184,6 +184,8 @@ def get_repository_info(
                 # get the latest issues with the tag
                 issues = []
                 for issue in good_first_issues:
+                    if issue.pull_request_urls:
+                        continue
                     issues.append(
                         {
                             "title": issue.title,


### PR DESCRIPTION
This PR addresses the issue of inaccurate "Amount of issue" counts displayed on the repository cards. The root cause was located in the populate.py script, which fetches data from the GitHub API.

Changes made:

Logic Update: Modified the loop within get_repository_info in gfi/populate.py to filter the good_first_issues set.

PR Filtering: Added a conditional check for pull_request_urls on each issue object. Since the GitHub API includes Pull Requests in the "issues" endpoint, this ensures that only actual open issues are counted and displayed.

Logging: Updated the logger to accurately reflect that it is processing a mix of potential issues and pull requests.

Closes #2561

AI Disclosure
In the spirit of transparency for open-source contributions:

AI Tool Used: Gemini 3 Flash.

Usage: Used for troubleshooting local environment errors (npm and git protocol issues) and identifying the specific attribute in the github3.py library (pull_request_urls) needed to filter the API data correctly.