### PR TITLE
Add usemoss/moss to data/repositories.toml

### DIFF
--- a/data/repositories.toml
+++ b/data/repositories.toml
@@ -757,6 +757,7 @@ repositories = [
   'github.com/unoplatform/uno',
   'github.com/UPC/ravada',
   'github.com/updatecli/updatecli',
+  'github.com/usemoss/moss',
   'github.com/uutils/coreutils',
   'github.com/valhalla/valhalla',
   'github.com/validatorjs/validator.js',


### PR DESCRIPTION
Adding [usemoss/moss](https://github.com/usemoss/moss) to the repository list.

Moss is a realtime semantic search runtime for AI agents, delivering sub-10ms search results.

## ℹ️ Repository information

The repository has:
- ✅ At least three issues with the `good first issue` label (8 open good first issues)
- - ✅ At least 10 contributors (10+ contributors)
- - ✅ Detailed README with setup instructions
- - ✅ CONTRIBUTING.md
- - ✅ BSD-2-Clause license
- - ✅ Actively maintained (commits as recent as today)